### PR TITLE
Align repository workflow, roadmap, and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,31 @@
 # Changelog
 
-All notable changes to the **Uncertainty Architecture** project will be documented in this file.
+All notable changes to the **Uncertainty Architecture** project are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Version numbers are assigned only when the project makes an explicit release decision.
+
+## [Unreleased]
+
+### Added
+
+- Expanded the repository into dedicated areas for doctrine, patterns, the AI Control Plane, reference architectures, and failure modes.
+- Established the UA Research Track under `content/research/` with an explicit boundary between historical research and normative framework material.
+- Added research publication, analysis, and framework-traceability templates.
+- Added a research-to-framework traceability scaffold.
+- Preserved five historical source snapshots under `content/raw/`.
+- Added normalized repository editions of five historical research publications under `content/research/publications/`.
+- Added a normalization report documenting provenance, transformations, quality checks, and unresolved publication metadata.
+- Added a canonical project roadmap in `ROADMAP.md`.
+
+### Changed
+
+- Simplified the repository contribution and research workflow for maintainer-led development while preserving deliberate review for normative, high-impact, automated, and externally contributed changes.
+- Reframed research review artifacts as proportional tools rather than mandatory components of every research update.
 
 ## [0.1.0] - 2025-12-09
 
 ### Added
+
 - Initial repository initialization.
 - Core documentation structure (`README.md`, `LICENSE`, `CONTRIBUTING.md`).
 - Definition of Uncertainty Architecture core concepts, Control Plane pattern, and Actuator/Sensor/Controller model.
@@ -16,19 +35,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Before the formal initialization of this repository, the Uncertainty Architecture framework evolved through a series of public research articles, community stress tests, and industry validations.
 
 ### Dec 2025
+
 - **Community Validation:** Public stress-test of the framework in the Data Science community (Reddit).
-    - *Result:* Validation from 33,000+ engineers with 90% upvote rate.
-    - [View Discussion](https://www.reddit.com/r/learndatascience/s/zLnN4sYftb)
+  - *Result:* Validation from 33,000+ engineers with 90% upvote rate.
+  - [View Discussion](https://www.reddit.com/r/learndatascience/s/zLnN4sYftb)
 - **Publication:** "Why AI Governance is Actually Control Theory" (LinkedIn).
-    - *Focus:* Establishing the link between Control Theory and AI Governance.
-    - [Read Article](https://www.linkedin.com/pulse/uncertainty-architecture-why-ai-governance-actually-control-oborskyi-oqhpf/)
+  - *Focus:* Establishing the link between Control Theory and AI Governance.
+  - [Read Article](https://www.linkedin.com/pulse/uncertainty-architecture-why-ai-governance-actually-control-oborskyi-oqhpf/)
 
 ### Nov 2025
+
 - **Publication:** "Uncertainty Architecture: A Modern Approach" (LinkedIn).
-    - *Focus:* Designing LLM systems with uncertainty as a core architectural component.
-    - [Read Article](https://www.linkedin.com/pulse/uncertainty-architecture-modern-approach-designing-llm-oborskyi-keqbf/)
+  - *Focus:* Designing LLM systems with uncertainty as a core architectural component.
+  - [Read Article](https://www.linkedin.com/pulse/uncertainty-architecture-modern-approach-designing-llm-oborskyi-keqbf/)
 
 ### Jul 2025
+
 - **Publication:** "Architecting Uncertainty: A Modern Guide" (LinkedIn).
-    - *Focus:* The initial guide on LLM-based system architecture.
-    - [Read Article](https://www.linkedin.com/pulse/architecting-uncertainty-modern-guide-llm-based-vitalii-oborskyi-0qecf/)
+  - *Focus:* The initial guide on LLM-based system architecture.
+  - [Read Article](https://www.linkedin.com/pulse/architecting-uncertainty-modern-guide-llm-based-vitalii-oborskyi-0qecf/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,82 +1,103 @@
 # Contributing to Uncertainty Architecture
 
-Thank you for your interest in contributing! This repository defines a shared doctrine, operational patterns, and reference architectures for building AI-integrated systems responsibly. Contributions help us keep the doctrine evolving and accurate.
+Thank you for your interest in contributing. This repository develops a shared doctrine, operational patterns, research record, and reference material for building and governing AI-integrated systems responsibly.
 
----
+## 1. What this repository accepts
 
-## 1. What This Repository Accepts
+Contributions may include:
 
-We focus on **doctrine, operational guidance, and controlled reference artifacts**. Contributions may include:
+- Doctrine and glossary clarifications in `00-doctrine/`
+- Reusable system and interface patterns in `01-patterns/`
+- AI Control Plane artifacts in `02-ai-control-plane/`
+- Reference architectures in `03-reference-architectures/`
+- Failure modes and anti-patterns in `04-failure-modes/`
+- Historical publications, research analyses, synthesis, and traceability material in `content/research/`
+- Diagrams and visual references in `assets/`
+- Small maintenance utilities in `scripts/`
+- Reusable repository templates in `templates/`
 
-- Documentation: new explanations, clarifications, diagrams (`docs/`, `assets/`)  
-- Specifications: normative language, term definitions, patterns (`spec/`, `patterns/`)  
-- Reference Architectures: concrete examples (`reference-architecture/`)  
-- Prompts and Golden Sets: controlled, versioned interface artifacts (`prompts/`, `golden-sets/`)  
-- Scripts and tooling: small utilities to maintain the repository (`scripts/`)  
-- Examples: illustrative end-to-end workflows (`examples/`)  
+We do not accept:
 
-> ⚠️ We do **not accept**:
-> - Large AI agents, universal SDKs, or frameworks  
-> - Arbitrary model output dumps or prompt experiments outside controlled patterns  
-> - Non-deterministic artifacts without documentation and versioning  
+- Large universal agent frameworks or SDKs unrelated to the specification
+- Uncurated model-output dumps or prompt experiments without context and versioning
+- Normative claims presented without rationale, scope, and operational implications
+- Changes that silently rewrite attributed historical work
 
----
+## 2. Repository ownership and attribution
 
-## 2. Zones of Ownership
+Vitalii Oborskyi is the project creator and primary maintainer. He retains final authority over repository scope and merges.
 
-To keep contributions clear and maintainable:
+Attributed work by named contributors must not be materially changed, reassigned, or presented as consensus without involving the relevant contributor where reasonably possible.
 
-| Area                      | Owner       | Notes                                                        |
-| ------------------------- | ----------- | ------------------------------------------------------------ |
-| Operating Model           | Vitalii     | Team functions, roles, rituals, decision boundaries          |
-| Reference Architectures   | Sam         | Implementation patterns, judgment nodes, persona design      |
-| Prompts                   | Sam         | Prompt registry, persona scaffolding, input/output contracts |
-| Doctrine, Specs, Glossary | Vitalii&Sam | Core definitions, shared language, control-theory framing    |
-| Scripts & Templates       | Anyone      | Must follow repository conventions                           |
+External contributions are welcome. Reviewers may be invited based on subject matter rather than a fixed approval hierarchy.
 
-> Each pull request should clearly indicate which owner is responsible for reviewing.
+## 3. Lightweight maintainer workflow
 
----
+The project currently operates as a maintainer-led open specification.
 
-## 3. Contribution Process
+A maintainer may commit minor changes directly when they are limited to:
 
-1. **Fork the repository**  
-2. **Create a branch** named descriptively (e.g., `docs/metrics-update`)  
-3. **Make your changes** using the repository structure  
-4. **Add or update README.md** in the folder if necessary  
-5. **Ensure compliance** with licensing and contribution guidelines  
-6. **Submit a pull request** with a clear description and specify the owner for review  
+- typos and formatting;
+- navigation and broken links;
+- metadata and frontmatter;
+- changelog and roadmap maintenance;
+- non-substantive editorial clarification.
 
----
+A branch and pull request are recommended for:
 
-## 4. Writing Guidelines
+- substantial documentation changes;
+- automation-generated changes;
+- multi-file updates;
+- changes where reviewing the full diff is useful;
+- externally contributed changes.
 
-- Keep language **clear and precise**  
-- Avoid speculative or magic-based statements about LLMs  
-- Use **control-theory framing** when describing interfaces, patterns, and judgment boundaries  
-- Include examples or diagrams wherever helpful  
+Draft pull requests are optional. External review is encouraged where it adds value, but it is not required for ordinary maintainer-authored work.
 
----
+## 4. Changes requiring deliberate review
 
-## 5. Licensing
+Use a branch and pull request, and seek appropriate review where practical, for changes that:
 
-This repository uses a **dual-license model**:
+- modify normative doctrine;
+- introduce or materially change a pattern;
+- change core terminology;
+- introduce mandatory roles, gates, controls, or processes;
+- restructure major repository sections;
+- promote research findings into the normative framework;
+- make significant scientific, legal, safety, governance, or compliance claims;
+- materially affect another contributor's attributed work.
 
-- Documentation, doctrine, and specifications: **CC BY 4.0**  
-- Code, scripts, and reference implementations: **Apache 2.0**
+The purpose of review is to improve the specification, not to create ceremony around routine maintenance.
 
-All contributions must comply with the applicable license for the files being modified.
+## 5. External contribution process
 
----
+1. Fork or branch from the current default branch.
+2. Keep the change focused and use the current repository structure.
+3. Explain what changed, why it changed, and whether the change is research, normative guidance, or maintenance.
+4. Update local navigation or supporting documentation where needed.
+5. Confirm licensing and attribution requirements.
+6. Open a pull request for maintainer review.
 
-## 6. Review and Merge
+One logical change per pull request is a useful default for substantial work, but tightly related updates may be grouped when that makes review clearer.
 
-- Vitalii and Sam will **review PRs** in their respective areas of ownership  
-- Minor fixes (typos, formatting, template updates) may be merged by maintainers  
-- Larger contributions may require discussion and iterative improvements  
+## 6. Writing guidelines
 
----
+- Keep language clear, precise, and operational.
+- Distinguish deterministic software behavior from probabilistic model judgment.
+- Avoid magical or absolute claims about LLM capabilities.
+- State scope, assumptions, and limitations.
+- Use control-theory framing where it genuinely clarifies feedback, sensing, correction, and containment.
+- Include examples or diagrams when they improve understanding.
+- Keep research findings separate from normative requirements until deliberately adopted.
 
-## 7. Code of Conduct
+## 7. Licensing
 
-Please also read the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) to ensure a welcoming and professional environment.
+This repository uses a dual-license model:
+
+- Documentation, doctrine, specifications, and research material: CC BY 4.0
+- Code, scripts, and reference implementations: Apache 2.0
+
+All contributions must comply with the applicable license and preserve required attribution. See [LICENSING.md](LICENSING.md).
+
+## 8. Code of conduct
+
+Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and help maintain a professional, constructive environment.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,104 @@
+# Uncertainty Architecture Roadmap
+
+Uncertainty Architecture is being developed as a practical open specification for engineering and operating software that delegates part of its behavior to probabilistic model judgment.
+
+This roadmap is the canonical detailed view of project direction. It distinguishes completed work, active work, near-term priorities, and later possibilities without attaching speculative dates.
+
+## Status legend
+
+- **Completed** — present in the repository and accepted as the current project baseline
+- **Active** — currently being developed or consolidated
+- **Next** — intended after the active work reaches a stable checkpoint
+- **Later** — valuable, but not required for the current framework spine
+
+## Phase 1 — Concept Validation
+
+**Status: Completed**
+
+Established the initial thesis and public evidence that AI-enabled systems require explicit engineering at the boundary between deterministic software and probabilistic model judgment.
+
+Completed outcomes:
+
+- initial Uncertainty Architecture publications;
+- control-theory framing for AI governance;
+- deterministic-core and model-judgment distinction;
+- AI Control Plane concept;
+- public and expert feedback;
+- initial repository structure and licensing model.
+
+## Phase 2 — Framework Spine
+
+**Status: Active**
+
+The objective is to consolidate the existing research into a coherent, bounded specification that explains what UA governs, how its parts relate, and what remains non-normative.
+
+### Completed in this phase
+
+- Research Track structure established under `content/research/`;
+- historical raw source snapshots preserved under `content/raw/`;
+- five historical publications normalized and archived under `content/research/publications/`;
+- provenance and normalization report added;
+- research-to-framework traceability scaffold created;
+- repository contribution and research workflow simplified for maintainer-led development.
+
+### Active and next milestones
+
+- [ ] Complete a cross-publication research synthesis.
+- [ ] Identify stable concepts, later refinements, contradictions, and superseded claims.
+- [ ] Review terminology, including the relationship between Behavioral Software, Thinking Systems, and agentic systems.
+- [ ] Produce a concise framework-spine proposal.
+- [ ] Clarify normative boundaries across Doctrine, Patterns, AI Control Plane, Operating Model, Reference Architectures, Failure Modes, and practical artifacts.
+- [ ] Improve repository navigation so readers can move from the overview to research and normative material without ambiguity.
+
+## Phase 3 — Patterns and Failure Modes
+
+**Status: Next**
+
+The objective is to turn the framework spine into reusable engineering guidance.
+
+Planned outcomes:
+
+- boundary patterns between deterministic control and model judgment;
+- containment, validation, retry, fallback, and escalation patterns;
+- drift and verification patterns;
+- Human-in-the-Loop and Human-on-the-Loop patterns;
+- failure-mode taxonomy grounded in operational examples;
+- explicit anti-patterns and conditions where AI should not be used.
+
+## Phase 4 — Operating Model and Practical Artifacts
+
+**Status: Next**
+
+The objective is to make UA usable by small and medium-sized engineering teams without requiring a large governance organization.
+
+Planned outcomes:
+
+- lightweight responsibility and decision model;
+- release, incident, change, and learning loops;
+- control-loop design guidance;
+- risk and tolerance mapping;
+- control-economics guidance;
+- an SMB-facing artifact for estimating required controls and their operational cost;
+- worked examples and adoption guidance.
+
+## Phase 5 — Optional Tooling and Reference Implementations
+
+**Status: Later**
+
+Tooling is optional and must serve the specification rather than redefine it.
+
+Possible outcomes:
+
+- small validation or repository-maintenance utilities;
+- example prompt, policy, and evaluation registries;
+- reference control-plane implementations;
+- executable examples and architecture demonstrations;
+- reusable templates generated from stable specification components.
+
+No universal SDK or platform is currently planned.
+
+## Current priority
+
+The immediate priority is not additional tooling. It is to complete the research synthesis and establish the framework spine, then derive one practical SMB-facing control-loop and risk-mapping artifact from that spine.
+
+The project optimizes for durable clarity, traceability, and practical usefulness rather than rapid expansion of repository volume.

--- a/content/research/review-process.md
+++ b/content/research/review-process.md
@@ -3,7 +3,7 @@ title: UA Research Review Process
 artifact_type: research-process
 status: draft
 created: 2026-07-24
-updated: 2026-07-24
+updated: 2026-07-25
 license: CC-BY-4.0
 ---
 
@@ -11,41 +11,41 @@ license: CC-BY-4.0
 
 ## Purpose
 
-This process governs how published and unpublished research is introduced into the Uncertainty Architecture repository and how research findings may later influence the normative framework.
+This process explains how published and unpublished research enters the Uncertainty Architecture repository and how research may later influence the normative framework.
 
-The goal is to prevent research ingestion, historical rewriting, methodological decisions, and repository restructuring from being mixed into one change.
+Its purpose is to preserve intellectual history, expose uncertainty and contradiction, and prevent research material from silently becoming methodology. It is not intended to impose heavyweight ceremony on routine maintainer work.
 
 ## Core principles
 
-### Planning before modification
+### Research is not automatically normative
 
-Every repository change starts with analysis and an explicit scope. Implementation begins only after the proposed scope has been reviewed and approved.
-
-### One logical change per pull request
-
-Each pull request should be small enough to answer one coherent review question. A source-specific research pull request should not silently redesign unrelated doctrine, patterns, roles, or navigation.
-
-### Research before methodology
-
-A published statement is not automatically a framework requirement. Research is preserved, analyzed, compared with later work, and only then considered for normative adoption.
+A published statement, presentation claim, working note, or historical recommendation is not automatically a framework requirement. Research is preserved and interpreted before any deliberate normative adoption.
 
 ### Preserve intellectual history
 
-Historical publications keep their original concepts and terminology. Current analysis may explain that a concept was refined, renamed, contradicted, or superseded, but the archived source is not rewritten to make the evolution disappear.
+Historical publications keep their original concepts and terminology. Repository editions may normalize formatting, metadata, links, and obvious copy errors, but they must not rewrite the past to make later evolution disappear.
 
 ### Expose uncertainty and contradiction
 
-The analysis should record weak evidence, over-strong claims, unresolved terminology, conflicting taxonomies, and later corrections. Editorial cleanup must not create false consensus.
+Research work should identify weak evidence, over-strong claims, unresolved terminology, conflicting taxonomies, later corrections, and limits of applicability. Editorial cleanup must not create false consensus.
 
-## Standard source pull request
+### Use proportional process
 
-A pull request reviewing one research source should normally include three components.
+The amount of process should match the risk and impact of the change. A typo fix, metadata update, or lightweight research note does not need the same workflow as a normative doctrine change.
 
-### 1. Repository edition
+### Human control over automated changes
 
-A normalized archive, translation, consolidated edition, or research note.
+Automated agents may prepare and validate changes, but they must not merge, force-push, delete branches, rewrite history, or make unscoped normative decisions without explicit human instruction.
 
-It must identify:
+## Supported research work types
+
+Research may be added or developed as any of the following:
+
+### Repository edition
+
+A normalized archive, translation, consolidated edition, or research note preserving a source for future use.
+
+Where available, it should identify:
 
 - original title and author;
 - publication date;
@@ -55,105 +55,95 @@ It must identify:
 - material transformations;
 - applicable license.
 
-Substantive arguments should be preserved. Platform-specific promotional material, duplicate biographies, broken links, and obvious formatting errors may be removed or corrected.
+### Source-specific analysis
 
-### 2. Research analysis
+A focused analysis of one source, including its question, assumptions, findings, current relevance, later refinements, contradictions, terminology evolution, and possible contribution to UA.
 
-A separate companion document should evaluate:
+### Multi-source synthesis
 
-- the question investigated;
-- the scope and assumptions;
-- key findings;
-- contribution to UA;
-- current relevance;
-- later refinements;
-- contradictions with prior or later work;
-- terminology evolution;
-- claims requiring softer formulation;
-- candidate framework components;
-- unresolved questions.
+A comparison across several publications, talks, or research notes intended to identify stable concepts, changes in position, contradictions, and the emerging framework spine.
 
-### 3. Traceability delta
+### Terminology or contradiction review
 
-The pull request updates the traceability matrix only with findings derived from that source.
+A focused document that resolves, narrows, or records disagreement around terminology, taxonomies, thresholds, or competing claims.
 
-Each entry identifies:
+### Framework-candidate note
 
-- the research finding;
-- the source;
-- the possible framework destination;
-- current status;
-- work needed before normative adoption.
+A proposal translating one or more research findings into a possible Doctrine, Pattern, Operating Model, Reference Architecture, Failure Mode, or practical artifact.
 
-## What a source pull request must not do
+### Lightweight research note
 
-Unless explicitly scoped and approved, a source pull request must not:
+A bounded record derived from a talk, working session, operational observation, external critique, or emerging question when a full source review is unnecessary.
 
-- activate a new doctrine;
-- declare a framework candidate normative;
-- rename the main system category across the repository;
-- introduce mandatory new job titles;
-- move or delete existing framework sections;
-- change repository-wide navigation;
-- merge directly into `main`;
-- merge its own pull request.
+## Optional review artifacts
 
-## Review questions
+The following are available tools rather than mandatory components of every research change:
 
-Each source pull request should answer:
+- repository edition;
+- research analysis;
+- traceability delta;
+- contradiction review;
+- terminology review;
+- framework-candidate proposal.
 
-1. What was the author actually investigating?
-2. Which conclusions are still defensible?
-3. Which conclusions were later refined or contradicted?
-4. Which terms changed meaning over time?
-5. Which numerical thresholds are examples rather than universal requirements?
-6. What belongs in Doctrine, Lifecycle, Patterns, Operating Model, Reference Architectures, or Artifacts?
-7. What should remain research context only?
-8. What requires a separate RFC or methodology proposal?
-9. Does the source add something genuinely new, or repeat an earlier claim in different language?
-10. What would an SMB team need to see on the surface, and what should remain in technical depth?
+Use the artifacts that make the reasoning visible and proportionate to the change.
 
-## Transition from research to framework
+## Research-to-framework transition
 
-The intended flow is:
+The typical flow is:
 
 ```text
-Research Source
-→ Repository Edition
-→ Research Analysis
-→ Contradiction and Evolution Review
+Research Source or Observation
+→ Repository Edition or Research Note when useful
+→ Analysis or Multi-Source Synthesis
+→ Contradiction and Terminology Review when needed
 → Framework Candidate
-→ RFC or Methodology Proposal when required
-→ Normative Framework
+→ Deliberate Normative Decision
 → Practical Artifact or Reference Implementation
 ```
 
-No step is automatic.
+No step is automatic, and not every item requires every intermediate document.
 
-## Planned pull request sequence
+## Changes requiring deliberate framework review
 
-### PR 0 — Research scaffolding
+A research change should receive explicit review before it:
 
-Defines the research index, review process, templates, status vocabulary, and initial traceability structure.
+- activates or materially modifies doctrine;
+- declares a framework candidate normative;
+- renames a core system category across the repository;
+- introduces mandatory job titles, gates, controls, or processes;
+- changes major repository-wide navigation or structure;
+- turns illustrative thresholds into universal requirements;
+- materially changes attributed work by another contributor.
 
-### Source review pull requests
+These changes should normally use a dedicated branch and pull request so the full diff and rationale are visible.
 
-One pull request per major article or synthesis source.
+## Practical branch and pull-request guidance
 
-### Final research synthesis
+One logical change per pull request remains a useful default for substantial work. It is not an absolute rule for every maintainer edit.
 
-Compares the complete track, identifies stable concepts and contradictions, and proposes the framework spine.
+Dedicated branches and pull requests are recommended for:
 
-### Separate terminology review
+- major research synthesis;
+- normative or high-impact changes;
+- externally contributed work;
+- automation-generated changes;
+- multi-file restructuring;
+- changes requiring subject-matter review.
 
-Evaluates the move from historical terms such as Behavioral Software toward a possible Thinking Systems taxonomy, including its relationship to agentic systems.
+Draft pull requests are optional. Minor maintainer-authored editorial, metadata, navigation, roadmap, or changelog updates may be committed directly.
 
-### Separate methodology series
+The project owner retains final merge authority.
 
-Only after research synthesis should the project formalize lifecycle, risk and tolerance models, control-loop design, Human-in-the-Loop, evaluation, canary validation, control economics, responsibilities, and repository navigation.
+## Current research direction
 
-## Branch and merge policy
+The historical repository editions are now preserved under `content/research/publications/`. The next major research task is a cross-publication synthesis identifying:
 
-All changes are prepared on a dedicated branch and opened as a Draft Pull Request against `main`.
+- concepts that remained stable;
+- concepts that were refined or superseded;
+- unresolved contradictions;
+- terminology requiring separate review;
+- candidates for the framework spine;
+- material that should remain research context only.
 
-The project owner reviews the diff and performs the merge. Automated agents must not merge, delete the branch, force-push, or rewrite history without an explicit instruction.
+Source-specific analysis may still be added where it produces useful evidence or resolves a concrete question.


### PR DESCRIPTION
## What changed

- simplified `CONTRIBUTING.md` for a maintainer-led project while preserving deliberate review for normative, high-impact, automated, and external changes;
- replaced the mandatory one-source/one-PR research ceremony with a proportional research workflow;
- populated `ROADMAP.md` as the canonical detailed roadmap;
- added an `Unreleased` changelog section covering the Research Track, historical publication archive, provenance work, and workflow update.

## Why

The repository's earlier governance documents were intentionally conservative during automated import and normalization of historical research. That import is complete. The documented process now needs to match the current reality: Vitalii is the primary maintainer and should be able to make ordinary edits without simulating a multi-party standards body.

The change preserves the important controls:

- research remains non-normative until deliberately adopted;
- historical work and attribution remain protected;
- substantial, normative, externally contributed, and automation-generated changes should use branches and visible diffs;
- automated agents cannot merge or rewrite history without explicit human instruction.

## Scope boundaries

This PR does not modify doctrine, patterns, the AI Control Plane, failure modes, reference architectures, raw research sources, or normalized publication bodies.

## Validation

- reviewed the edited documents for contradictory requirements around Draft PRs, mandatory external review, direct maintainer commits, and one-source-per-PR rules;
- verified that the contribution paths match the current repository structure;
- retained the existing licensing split and historical changelog chronology;
- did not assign a new numbered release.