### PR TITLE
Document UA project history and independent recognition

### DIFF
--- a/content/history/README.md
+++ b/content/history/README.md
@@ -1,0 +1,29 @@
+# Uncertainty Architecture Project History
+
+This directory documents the public development of Uncertainty Architecture as a research initiative and open specification.
+
+It is intentionally separate from:
+
+- the normative framework in `00-doctrine/`, `01-patterns/`, `02-ai-control-plane/`, `03-reference-architectures/`, and `04-failure-modes/`;
+- the research corpus and analyses in `content/research/`;
+- the repository release history in `CHANGELOG.md`.
+
+The material here records public milestones, talks, independent references, and third-party interpretations. Inclusion does **not** imply endorsement of every UA claim, formal adoption of the specification, partnership, or organizational approval unless a source explicitly states that.
+
+## Documents
+
+- [Project timeline](timeline.md) — selected milestones in the development of UA.
+- [Independent references and recognition](external-recognition.md) — public third-party references, interpretations, and contextual validation.
+- [Talks and presentations](talks.md) — public evidence of presentations and practitioner discussion.
+
+## Evidence policy
+
+Entries should:
+
+1. link to a public primary source where possible;
+2. distinguish a direct citation from a repost, comment, recommendation, advisory relationship, or invited talk;
+3. summarize what the source actually establishes without inflating it into formal adoption;
+4. avoid using follower counts, impressions, reactions, or self-authored promotional claims as evidence of technical validity;
+5. record corrections when a source becomes unavailable or its meaning is disputed.
+
+A self-authored summary may be retained as a navigation aid, but it is not treated as independent evidence.

--- a/content/history/external-recognition.md
+++ b/content/history/external-recognition.md
@@ -1,0 +1,102 @@
+# Independent References and Recognition
+
+This document records public third-party references to Uncertainty Architecture (UA). It is an evidence ledger, not a claim of formal adoption, partnership, or universal validation.
+
+## Christophe Kolb and Taller
+
+### May 14, 2026 — “The Probability-Control Theory of Agentic AI”
+
+Christophe Kolb, CEO of Taller, published an independent interpretation of agentic AI reliability that explicitly cited Vitalii Oborskyi’s Uncertainty Architecture. The post used the “Gambler / Weatherman” framing to distinguish creative stochastic behavior from the control layer responsible for sensing, constraints, evaluation, escalation, and operational viability.
+
+**What this establishes:** UA was used as a conceptual foundation in an independent industry explanation of agentic-system control.
+
+**What it does not establish:** formal adoption of the UA specification by Taller or endorsement of every UA claim.
+
+- [Source: Christophe Kolb — The Probability-Control Theory of Agentic AI](https://www.linkedin.com/posts/christophekolb_the-probability-control-theory-of-agentic-activity-7460778173597786114-rWAh)
+
+### July 14, 2026 — LLMs and control theory visual
+
+Christophe Kolb published a visual explainer on why control theory maps to LLM behavior and publicly described Uncertainty Architecture as one of the most serious treatments of the problem he had encountered. He stated that the visual drew on UA ideas to explain probability distributions, prompts and retrieval as control signals, and closed-loop feedback.
+
+Taller subsequently amplified the material through its company channel, explicitly stating that the visual drew on UA to explain how stochastic behavior can become more observable, bounded, and governable.
+
+**What this establishes:** a second, more explicit use of UA concepts by both Taller’s CEO and the company’s public communications.
+
+- [Source: Christophe Kolb — LLMs and control theory](https://www.linkedin.com/posts/christophekolb_llms-and-control-theory-ugcPost-7482833374932410368-R7AJ/)
+- [Source: Taller company page](https://www.linkedin.com/company/taller-technologies/)
+
+## Michael Risch
+
+### April 29, 2026 — operational interpretation of UA
+
+Michael Risch published a detailed interpretation of Uncertainty Architecture as applied control theory for agentic organizations. He translated the framework into four operational layers: actuators, constraints, sensors, and an operating model, and connected them to concrete roles such as Prompt Steward, Evaluation Owner, and AI Reliability Engineer.
+
+**What this establishes:** an independent practitioner operationalized UA concepts into roles, release gates, and governance practices rather than merely reposting the original article.
+
+- [Source: Michael Risch — Uncertainty Architecture: Why AI Governance is Actually Control Theory](https://www.linkedin.com/posts/michael-risch-ab8b423_uncertainty-architecture-why-ai-governance-activity-7455141331162681344-i-8g)
+
+## Markus Kopko
+
+### Public recommendation and CPMAI mapping
+
+Markus Kopko, CPMAI Lead Coach and participant in PMI AI standards work, publicly recommended Vitalii Oborskyi’s contribution and described the Model Control Plane as a practical bridge between strategy and engineering reality.
+
+In May 2026, Kopko also published a detailed mapping between the UA control-theory framing and the CPMAI lifecycle, connecting constraints, sensors, named roles, and go/no-go gates to AI project governance.
+
+**What this establishes:** independent recognition from an AI project-governance practitioner and a concrete conceptual mapping between UA and CPMAI practices.
+
+**What it does not establish:** formal PMI endorsement of UA.
+
+- [Source: Markus Kopko — CPMAI mapping of UA](https://www.linkedin.com/posts/markuskleinpmp_uncertainty-architecture-why-ai-governance-activity-7462053122773827584-mKwf)
+- [Supporting source: Vitalii Oborskyi profile recommendation](https://www.linkedin.com/in/vitaliioborskyi/)
+
+## Matthew Skelton
+
+### Public acknowledgement and Team Topologies context
+
+Matthew Skelton, co-author of *Team Topologies*, publicly acknowledged the emergence of UA and expressed interest in its further development. UA has also been discussed in relation to organizational flow, cognitive load, and the operating-model consequences of AI-enabled systems.
+
+**What this establishes:** public interest from a recognized practitioner in socio-technical organization design.
+
+**Evidence limitation:** the currently retained public evidence is a comment and self-authored milestone summary rather than a standalone technical review. This entry should not be represented as formal validation of the full framework.
+
+- [Source: UA public milestone summary and Matthew Skelton comment](https://www.linkedin.com/posts/vitaliioborskyi_ua-1-ugcPost-7461016808725164033-pQg_/)
+
+## Otman Basir
+
+### Academic convergence and advisory context
+
+Prof. Otman Basir’s Social Responsibility Stack independently argues for engineered, control-theoretic responsibility loops around AI systems. In a public discussion of UA, Basir linked this work as relevant to the same control-governance problem.
+
+Basir later joined the UA initiative as an academic advisor.
+
+**What this establishes:** conceptual convergence between UA and independently published academic work, plus an advisory relationship.
+
+**What it does not establish:** that the Social Responsibility Stack was derived from UA or that either framework is identical to the other.
+
+- [Source: Social Responsibility Stack paper](https://arxiv.org/abs/2512.16873)
+- [Source context: discussion under Michael Risch’s UA post](https://www.linkedin.com/posts/michael-risch-ab8b423_uncertainty-architecture-why-ai-governance-activity-7455141331162681344-i-8g)
+
+## Corning practitioner exposure
+
+UA was presented during Corning Incorporated’s internal Learn-AI-Palooza, with public follow-up from Rod Montgomery describing the session as a highlight and emphasizing that many important AI risks emerge above the code level—in teams, operating models, governance, and accountability.
+
+This is documented in more detail in [Talks and presentations](talks.md).
+
+## Self-authored social proof ledger
+
+Vitalii Oborskyi published a visual summary of several public references in May 2026. It is retained as a useful navigation index but is not treated as independent evidence by itself.
+
+- [UA #1 milestone summary](https://www.linkedin.com/posts/vitaliioborskyi_ua-1-ugcPost-7461016808725164033-pQg_/)
+
+## Inclusion standard
+
+Future entries should be added only when they involve at least one of the following:
+
+- a direct public citation of UA;
+- independent interpretation or application of UA concepts;
+- an invited talk or practitioner workshop with public evidence;
+- a formal recommendation or advisory relationship;
+- a substantive critique that materially influences the framework.
+
+Likes, profile views, generic reactions, and unverified private conversations should not be included.

--- a/content/history/talks.md
+++ b/content/history/talks.md
@@ -1,0 +1,27 @@
+# Talks and Presentations
+
+This document records public evidence of talks, workshops, and practitioner sessions involving Uncertainty Architecture.
+
+## July 2026 — Corning Incorporated Learn-AI-Palooza
+
+Vitalii Oborskyi joined an internal technical AI workshop at Corning Incorporated as an external speaker. The session focused on **Designing Non-Deterministic Systems** and used Uncertainty Architecture to examine how probabilistic model judgment changes software architecture, delivery assumptions, governance, and accountability.
+
+Topics included:
+
+- the transition from deterministic software paths to behavioral systems;
+- the use of control theory for socio-technical feedback loops;
+- separating deterministic constraints from model judgment;
+- risks that emerge at the level of teams, operating models, ownership, and escalation rather than only in source code;
+- the need for sensing, correction, containment, and human decision authority.
+
+Rod Montgomery publicly described the session as one of the highlights of the event and emphasized that the most important risks of AI participation in execution and business logic often sit above the code layer.
+
+**What this establishes:** UA was presented and discussed with an enterprise technology audience, and the host independently documented the relevance of the system-level framing.
+
+**What it does not establish:** formal adoption of UA by Corning, approval by Corning leadership outside the workshop, or a public commercial engagement.
+
+- [Source: Rod Montgomery’s public post](https://www.linkedin.com/posts/roderickm_one-of-the-highlights-of-our-recent-learn-al-palooza-share-7480960627696558081-9L4z/)
+
+## Entry criteria
+
+A talk should be added here when there is public evidence of the session and UA is a substantive topic rather than a passing reference. Private meetings, sales calls, and unconfirmed invitations should not be listed.

--- a/content/history/timeline.md
+++ b/content/history/timeline.md
@@ -1,0 +1,83 @@
+# Uncertainty Architecture Project Timeline
+
+This timeline records selected public milestones in the development of Uncertainty Architecture. It is not a release log; repository changes belong in `CHANGELOG.md`.
+
+## 2025
+
+### July 29 — Initial public guide
+
+Publication of **“Architecting Uncertainty: A Modern Guide to LLM-Based Software.”**
+
+The article introduced the early architectural framing for software built around probabilistic model behavior.
+
+- [Source](https://www.linkedin.com/pulse/architecting-uncertainty-modern-guide-llm-based-vitalii-oborskyi-0qecf/)
+
+### November 19 — Modern UA formulation
+
+Publication of **“Uncertainty Architecture: A Modern Approach to Designing LLM Applications.”**
+
+This work developed the distinction between deterministic software and model judgment and framed uncertainty as an architectural property rather than an implementation defect.
+
+- [Source](https://www.linkedin.com/pulse/uncertainty-architecture-modern-approach-designing-llm-oborskyi-keqbf/)
+
+### December 9 — Repository initialization
+
+The Uncertainty Architecture repository was initialized as the public home of the framework.
+
+### December 11 — Governance as control theory
+
+Publication of **“Uncertainty Architecture: Why AI Governance is Actually Control Theory.”**
+
+The article established the Actuators–Sensors–Controller framing and positioned AI governance as an engineered feedback loop.
+
+- [Source](https://www.linkedin.com/pulse/uncertainty-architecture-why-ai-governance-actually-control-oborskyi-oqhpf/)
+
+## 2026
+
+### April 29 — Independent operational interpretation
+
+Michael Risch published an operational interpretation of UA for agentic organizations, translating the control loop into roles, evaluation gates, and governance practices.
+
+- [Source](https://www.linkedin.com/posts/michael-risch-ab8b423_uncertainty-architecture-why-ai-governance-activity-7455141331162681344-i-8g)
+
+### May 14 — Gambler / Weatherman framing
+
+Christophe Kolb cited UA in **“The Probability-Control Theory of Agentic AI,”** using it as part of an independent explanation of how creative model variance must be paired with a control layer.
+
+- [Source](https://www.linkedin.com/posts/christophekolb_the-probability-control-theory-of-agentic-activity-7460778173597786114-rWAh)
+
+### May 15 — Public milestone ledger
+
+Vitalii Oborskyi published a self-authored summary linking several independent references and practitioner responses. It is retained as a navigation aid rather than independent evidence.
+
+- [Source](https://www.linkedin.com/posts/vitaliioborskyi_ua-1-ugcPost-7461016808725164033-pQg_/)
+
+### May 18 — CPMAI mapping
+
+Markus Kopko published a detailed mapping between the UA control-theory framing and CPMAI practices, including constraints, sensors, named roles, and go/no-go gates.
+
+- [Source](https://www.linkedin.com/posts/markuskleinpmp_uncertainty-architecture-why-ai-governance-activity-7462053122773827584-mKwf)
+
+### May 22 — Beyond Embeddings
+
+Publication of **“Uncertainty Architecture: Beyond Embeddings — Neuro-Symbolic Verification of Semantic Drift in LLMs.”**
+
+The article introduced a bounded neuro-symbolic sensor pattern and extended UA into logic-level drift detection, control economics, sensor failure modes, and explicit no-go decisions.
+
+- [Source](https://www.linkedin.com/pulse/uncertainty-architecture-beyond-embeddings-semantic-oborskyi-1seuf/)
+
+### July 9 — Corning Learn-AI-Palooza public follow-up
+
+Rod Montgomery publicly documented Vitalii Oborskyi’s UA session at Corning Incorporated and highlighted the importance of system-level risks involving teams, operating models, governance, and accountability.
+
+- [Source](https://www.linkedin.com/posts/roderickm_one-of-the-highlights-of-our-recent-learn-al-palooza-share-7480960627696558081-9L4z/)
+
+### July 14 — Taller control-theory visual
+
+Christophe Kolb published a visual explainer drawing on UA concepts to show how prompts, context, retrieval, and feedback loops influence probabilistic model behavior. Taller subsequently amplified the material through its company channel.
+
+- [Source](https://www.linkedin.com/posts/christophekolb_llms-and-control-theory-ugcPost-7482833374932410368-R7AJ/)
+
+### July — Research Track and repository normalization
+
+The repository added a dedicated Research Track, preserved historical source snapshots, added normalized publication editions, and established provenance and traceability scaffolding. These repository changes are documented in `CHANGELOG.md`.


### PR DESCRIPTION
## What changed

- added `content/history/README.md` with a strict evidence policy separating project history from doctrine, research, and release history;
- added a chronological project timeline;
- added an independent references ledger covering Christophe Kolb and Taller, Michael Risch, Markus Kopko, Matthew Skelton, Otman Basir, and the Corning practitioner session;
- added a dedicated talks document for the Corning Learn-AI-Palooza session;
- explicitly distinguished citations, interpretations, recommendations, advisory relationships, and invited talks from formal adoption or organizational endorsement.

## Why

UA now has enough public development history that leaving these signals scattered across LinkedIn makes the project harder to assess. The repository needs a durable, evidence-conscious record without turning social proof into exaggerated validation claims.

## Evidence standard

The documents:

- prioritize public primary sources;
- do not treat likes, impressions, follower counts, or self-authored promotion as technical evidence;
- retain the self-authored `UA #1` post only as a navigation aid;
- state what each item establishes and what it does not establish;
- keep research publications such as `Beyond Embeddings` separate from independent recognition.

## Scope boundaries

This PR does not modify doctrine, patterns, terminology, the AI Control Plane, failure modes, research publication bodies, or raw historical sources.

## Dependency note

Root README navigation and detailed changelog alignment can be finalized after PR #4 is merged to avoid conflicting edits to governance documents.