### PR TITLE
Refine project history and repository navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-All notable changes to the **Uncertainty Architecture** project are documented in this file.
+All notable changes to the **Uncertainty Architecture repository and specification artifacts** are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Version numbers are assigned only when the project makes an explicit release decision.
+
+Project publications, talks, community discussions, and independent references are documented under [`content/history/`](content/history/) rather than repeated here.
 
 ## [Unreleased]
 
@@ -16,11 +18,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added normalized repository editions of five historical research publications under `content/research/publications/`.
 - Added a normalization report documenting provenance, transformations, quality checks, and unresolved publication metadata.
 - Added a canonical project roadmap in `ROADMAP.md`.
+- Added a project-history area separating the timeline, public talks, and independent references from release history and normative specification content.
 
 ### Changed
 
 - Simplified the repository contribution and research workflow for maintainer-led development while preserving deliberate review for normative, high-impact, automated, and externally contributed changes.
 - Reframed research review artifacts as proportional tools rather than mandatory components of every research update.
+- Clarified repository navigation and the distinct responsibilities of `README.md`, `ROADMAP.md`, `CHANGELOG.md`, `content/research/`, and `content/history/`.
 
 ## [0.1.0] - 2025-12-09
 
@@ -29,28 +33,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initial repository initialization.
 - Core documentation structure (`README.md`, `LICENSE`, `CONTRIBUTING.md`).
 - Definition of Uncertainty Architecture core concepts, Control Plane pattern, and Actuator/Sensor/Controller model.
-
-## [Pre-repository] - Foundational Research & Chronology
-
-Before the formal initialization of this repository, the Uncertainty Architecture framework evolved through a series of public research articles, community stress tests, and industry validations.
-
-### Dec 2025
-
-- **Community Validation:** Public stress-test of the framework in the Data Science community (Reddit).
-  - *Result:* Validation from 33,000+ engineers with 90% upvote rate.
-  - [View Discussion](https://www.reddit.com/r/learndatascience/s/zLnN4sYftb)
-- **Publication:** "Why AI Governance is Actually Control Theory" (LinkedIn).
-  - *Focus:* Establishing the link between Control Theory and AI Governance.
-  - [Read Article](https://www.linkedin.com/pulse/uncertainty-architecture-why-ai-governance-actually-control-oborskyi-oqhpf/)
-
-### Nov 2025
-
-- **Publication:** "Uncertainty Architecture: A Modern Approach" (LinkedIn).
-  - *Focus:* Designing LLM systems with uncertainty as a core architectural component.
-  - [Read Article](https://www.linkedin.com/pulse/uncertainty-architecture-modern-approach-designing-llm-oborskyi-keqbf/)
-
-### Jul 2025
-
-- **Publication:** "Architecting Uncertainty: A Modern Guide" (LinkedIn).
-  - *Focus:* The initial guide on LLM-based system architecture.
-  - [Read Article](https://www.linkedin.com/pulse/architecting-uncertainty-modern-guide-llm-based-vitalii-oborskyi-0qecf/)

--- a/README.md
+++ b/README.md
@@ -1,295 +1,154 @@
-# Uncertainty Architecture (UA): The Operational Open Specification for AI Governance
-
----
+# Uncertainty Architecture (UA)
 
 ## Engineering at the AI–Code Boundary
 
-**Uncertainty Architecture** is a doctrine and pattern language for building software systems in which part of the system’s behavior is delegated to **non-deterministic model judgment** (LLMs, agentic components, tool-using policies), while the surrounding system remains **deterministic, inspectable, and safe**.
+**Uncertainty Architecture** is an open doctrine and pattern language for building and operating software in which part of the system's behavior is delegated to **non-deterministic model judgment**, while the surrounding system remains **deterministic, inspectable, and governable**.
 
-UA is not about eliminating uncertainty or making AI “deterministic.” It is about **containing uncertainty**: deciding where determinism must hold, where judgment is unavoidable, and how the interface between the two is engineered, observed, and corrected over time.
+UA is not about eliminating uncertainty or pretending that AI can be made fully deterministic. It is about **containing uncertainty**: deciding where determinism must hold, where judgment is unavoidable, and how the boundary between the two is engineered, observed, and corrected over time.
 
-It builds on the idea of an **AI Control Plane** — a management and orchestration layer responsible for coordination, policy enforcement, evaluation loops, and risk-aware decision flows.
+The project is designed primarily for small and medium-sized engineering organizations that need practical control without building a large governance bureaucracy.
 
----
-## Strategic Vision: From Linear to Behavioral Software
+## The Core Shift
 
-While the industry uses the term "Agentic AI," we believe this is a transitional label. The fundamental shift occurring is not just about adding agents; it is the transition from **Linear Applications** to **Behavioral Applications**.
+Traditional software is mostly built from deterministic components and predefined execution paths. LLM-backed and agentic systems introduce components whose behavior remains probabilistic at runtime.
 
-- **Linear Software:** Deterministic, pre-defined paths. The developer explicitly codes *how* the system reaches the result.
-- **Behavioral Software:** Probabilistic, goal-oriented. The developer defines the *goal and constraints*, and the system navigates the path dynamically.
+UA calls this broader class **Behavioral Software**:
 
-**The Mission**
+- **Linear Software** follows explicitly coded paths.
+- **Behavioral Software** pursues goals within constraints while selecting or generating parts of the path dynamically.
 
-The primary goal of this framework is to provide SMB engineering teams with the necessary operational basis to successfully build, govern, and ship Behavioral Applications.
-
-Teams consistently fail with AI-enabled features for the same reasons:
-- They treat model output as if it were a stable API response.
-- They embed judgment inside prompts and mistake it for logic.
-- They overfit to dashboards and metrics while missing real-world failures.
-- They build “agentic” systems without clear boundaries, escalation paths, or fallbacks.
-
-These failures are not caused by stochasticity itself. They occur when teams lack a clear **interface doctrine** between deterministic software and probabilistic judgment.
-
-Uncertainty Architecture exists to fill that gap.
-
----
+The architectural problem is therefore not only model quality. It is how probabilistic judgment is connected to business rules, permissions, data, human authority, release processes, monitoring, and correction.
 
 ## What UA Is — and Is Not
 
-### UA *is*:
-- A shared way of **thinking**, **designing**, and **reviewing** systems at the AI–code boundary.
-- A collection of **interface patterns** for containment, evaluation, escalation, and fallback.
-- A tool-neutral **operational doctrine** grounded in real systems and real failure modes.
+UA is:
 
-### UA is *not*:
-- An SDK or universal agent framework.
-- A prompt-template pack.
-- A single metric or eval that “solves alignment”.
-- A compliance checklist or certification program.
+- a shared way of thinking about systems at the AI–code boundary;
+- a set of patterns for containment, evaluation, escalation, and fallback;
+- an operational doctrine for governing probabilistic behavior;
+- a tool-neutral specification intended to evolve through research and implementation evidence.
 
-UA does not prescribe a platform. It provides **conceptual tools** teams can adapt to their own architecture.
+UA is not:
 
----
+- an SDK or universal agent framework;
+- a prompt-template collection;
+- a single metric or evaluation method;
+- a compliance certification;
+- a claim that uncertainty can be removed from model behavior.
 
-## What UA Covers
+## Core Model
 
-UA operates at three complementary levels:
-
-### 1. Doctrine (How to Think)
-- What model judgment is operationally — and what it is not.
-- Where formal specification ends and interpretation begins.
-- Why false rigor (over-specified metrics, brittle schemas) fails in practice.
-
-### 2. Patterns (How to Build)
-- Boundary patterns between deterministic code and model judgment.
-- Containment mechanisms: guardrails, validation, retries, fallbacks.
-- Drift detection and structured review loops.
-
-### 3. Operating Model (How to Run)
-- Roles and decision points teams actually need.
-- Release gates for probabilistic components.
-- Incident handling and “battle-scar” feedback.
-
----
-
-## A Core Principle: Containment, Not Certainty
-
-UA treats AI governance as an **engineering activity**: the design of feedback and containment mechanisms required to operate systems with non-deterministic components.
-
-Control-theoretic ideas inform this work as practical engineering tools:
-- Feedback loops.
-- Instrumentation.
-- Correction mechanisms.
-
-However, UA also recognizes a structural limit: many correctness targets in AI-enabled systems are **interpretive** (usefulness, clarity, appropriateness, policy intent). These cannot be fully reduced to a scalar metric.
-
-For this reason, UA relies on **mixed evaluation**:
-- Quantitative signals where they are stable and meaningful.
-- Structured human judgment where goals are inherently interpretive.
-
-Metrics are treated as **operational instruments**, not exhaustive definitions of success.
-
----
-
-## The Operational Formula
-
-To bridge the gap between deterministic code and probabilistic models, we apply **Control Theory**. We define **AI Governance** not as bureaucracy, but as the engineered feedback loop required to stabilize the system.
+UA treats AI governance as an engineering control problem.
 
 > **Reliable AI = Actuators + Sensors + Controller**
 
-This maps abstract control concepts to concrete engineering artifacts:
+- **Actuators** shape and constrain behavior: prompts, schemas, policies, permissions, tools, model settings, and execution boundaries.
+- **Sensors** detect deviation: evaluations, golden scenarios, runtime signals, incidents, qualitative review, and drift monitoring.
+- **Controller** determines corrective action: release gates, ownership, escalation, rollback, retraining, prompt or policy changes, and human decision authority.
 
-*   **Actuators (The Execution):** Mechanisms that define and constrain the probability distribution.
-    *   *Artifacts:* **Prompt Registry**, **Versioned Prompts**, Hyperparameters, and JSON Schemas.
-*   **Sensors (The Measurement):** Instruments that detect drift and measure the distance from "Business Truth".
-    *   *Artifacts:* **Golden Sets** (Ground Truth), **Eval Pipelines**, and continuous Drift Monitoring.
-*   **Controller (The Governance):** The decision-making logic that adjusts the system based on error signals.
-    *   *Artifacts:* **The Operating Model**, **Release Gates**, and the Feedback Loop that updates the Registry based on Golden Set performance.
+This control loop surrounds a critical distinction:
 
----
+- **Deterministic Core** — business rules, invariants, authentication, data handling, auditability, safety constraints.
+- **Model Judgment** — interpretation, synthesis, classification under ambiguity, open-ended generation, and uncertain tool choice.
 
-## Deterministic Core and Model Judgment
+UA focuses on the boundary between these regions.
 
-UA makes an explicit distinction between:
-
-- **Deterministic Core:** Business rules, invariants, data handling, authentication, auditing, safety constraints.
-- **Model Judgment:** Interpretation, synthesis, classification under ambiguity, open-text generation, tool choice under uncertainty.
-
-The value of UA lies in how these two regions are **connected**, not in attempting to collapse one into the other.
-
----
-
-## The Boundary Layer (Control Plane Pattern)
-
-UA describes a recurring architectural pattern often referred to here as a **boundary layer** (sometimes called a “control plane” in the literature). This is not a product or platform, but a **pattern vocabulary**.
-
-The boundary layer is responsible for:
-- Mediating requests to model judgment.
-- Enforcing constraints and permissions.
-- Validating and gating outputs.
-- Routing retries, fallbacks, and escalation.
-- Maintaining versioning and auditability.
-
-It exists to make judgment **visible, bounded, and correctable**.
-
----
-
-## Evaluation as Instrumentation
-
-UA treats evaluation as instrumentation rather than proof. Common instruments include:
-- Regression suites and golden scenarios.
-- Red-team and edge-case probes.
-- Production monitoring and cost signals.
-- Incident tracking and postmortems.
-- Qualitative review checkpoints.
-
-No single instrument is sufficient. UA emphasizes **compositional sensing** over metric monoculture.
-
----
-
-## Conceptual Diagram
-The framework is structured around the **AI Control Plane**—a governance layer that separates business logic from probabilistic inference.
+## Conceptual Architecture
 
 ```mermaid
 graph TD;
-    A[Deterministic Core / Business Logic] -->|Request + Constraints| B(Boundary Layer);
+    A[Deterministic Core / Business Logic] -->|Request + Constraints| B[Boundary Layer / AI Control Plane];
     B -->|Bounded Invocation| C{Model Judgment / LLM};
     C -->|Candidate Output| B;
-    B -->|Validate + Gate| D[Quality & Safety Checks];
+    B -->|Validate + Gate| D[Quality, Safety, and Policy Checks];
     D -->|Pass| E[User / Downstream System];
     D -->|Fail| F[Fallback / Retry / Escalation];
     F --> B;
-   
-``` 
-   
-## Repository Scope & Structure
+```
 
-This repository is a **specification and doctrine project**, organized to reflect the logical flow from theory to implementation.
+## Repository Structure
 
-### Core Framework
+### Normative framework
 
-- [**📂 00-doctrine/**](./00-doctrine/)
-    
-    - **Phase 1: Spine.** Core concepts, boundary thinking, and the "Mental Model".
-    - _Contains:_ `glossary.md`(Shared language).
-- [**📂 01-patterns/**](./01-patterns/)
-    
-    - **Phase 2: Patterns.**Repeatable interface and containment patterns.
-    - _Focus:_ Judgment nodes, hard vs soft invariants, procedural gaskets.
-- [**📂 02-ai-control-plane/**](./02-ai-control-plane/)
-    
-    - **The Implementation Core.**Maps Control Theory to engineering artifacts.
-    - [**📂 00-actuators/**](./02-ai-control-plane/00-actuators/) — Prompts & Schemas (The Muscles).
-    - [**📂 01-sensors/**](./02-ai-control-plane/01-sensors/) — Evals, Golden Sets, Metrics (The Nerves).
-    - [**📂 02-controller/**](./02-ai-control-plane/02-controller/) — Roles, Rituals, Gates (The Brain).
-- [**📂 03-reference-architectures/**](./03-reference-architectures/)
-    
-    - Concrete examples of the doctrine in practice (e.g., Indranet).
-    - Demonstrates how to separate deterministic control from probabilistic judgment.
-- [**📂 04-failure-modes/**](./04-failure-modes/)
-    
-    - **Taxonomy of Entropy.**
-    - _Categories:_ Syntactic Entropy, Semantic Entropy, and Process Anti-Patterns.
+- [`00-doctrine/`](00-doctrine/) — core concepts, terminology, and boundary thinking.
+- [`01-patterns/`](01-patterns/) — reusable containment and interface patterns.
+- [`02-ai-control-plane/`](02-ai-control-plane/) — actuators, sensors, controllers, and operating controls.
+- [`03-reference-architectures/`](03-reference-architectures/) — worked architectural applications.
+- [`04-failure-modes/`](04-failure-modes/) — recurring technical and socio-technical failure modes.
 
-### Operational Assets
+### Supporting knowledge
 
-- [**📂 assets/**](./assets/) — Diagrams and visual references.
-- [**📂 scripts/**](./scripts/) — Automation for maintaining the repository.
-- [**📂 templates/**](./templates/) — Reusable templates (Daily notes, RFCs).
+- [`content/research/`](content/research/) — historical publications, research analysis, provenance, and research-to-framework traceability. Research material is non-normative until deliberately adopted into the specification.
+- [`content/history/`](content/history/) — project timeline, public talks, and independent references. This area records history without treating attention, discussion, or invited presentations as proof of adoption.
+- [`ROADMAP.md`](ROADMAP.md) — canonical project direction and future priorities.
+- [`CHANGELOG.md`](CHANGELOG.md) — repository and specification-artifact changes only.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution and review workflow.
 
----
+### Operational assets
 
-## Industry & Academic Validation
+- [`assets/`](assets/) — diagrams and visual references.
+- [`scripts/`](scripts/) — repository-maintenance automation.
+- [`templates/`](templates/) — reusable contribution and specification templates.
 
-This framework is not an isolated theory; it represents a convergence of industry best practices and emerging academic consensus.
+## Current Status
 
-### 1. PMI AI Standard Context
+**Active specification development.**
 
-The operational principles outlined here have been developed in dialogue with core members of the Project Management Institute (PMI) AI Standard Committee. The framework addresses the specific gap in "AI Risk Management" operationalization identified during standard development discussions.
+The current priority is to consolidate the research corpus into a coherent framework spine, clarify normative boundaries, and derive a practical SMB-facing artifact for mapping risks, required controls, and control cost.
 
-### 2. Academic Convergence (Control Theory)
+Detailed status and sequencing are maintained in [`ROADMAP.md`](ROADMAP.md).
 
-Independent academic research has recently confirmed the necessity of a control-theoretic approach to AI Governance.
+## Research and Project History
 
-- **Reference:** The Social Responsibility Stack (SRS) by Prof. Otman Basir (University of Waterloo), published on arXiv (Dec 2025).
-- **Convergence:** The academic conclusion that "responsibility must be an engineered control loop" mirrors the core thesis of Uncertainty Architecture.
-- [Link to arXiv:2512.16873](https://arxiv.org/abs/2512.16873)
+The repository intentionally separates three different records:
 
-### 3. Engineering Consensus
+- **Research evolution** explains how ideas developed and where claims originated.
+- **Project history** records publications, talks, and independent interpretations.
+- **Changelog** records what changed in the repository and specification artifacts.
 
-The framework underwent a public stress-test in the Data Science community (Dec 2025), receiving validation from 33,000+ engineers (90% Upvote) as a necessary evolution from "vibes-based" development to engineered reliability.
+This separation avoids using release history as a marketing timeline and prevents external references from being mistaken for technical validation.
 
-- [Reddit Discussion](https://www.reddit.com/r/learndatascience/s/zLnN4sYftb)
+Start here:
 
----
+- [Research Track](content/research/)
+- [Project timeline](content/history/timeline.md)
+- [Talks and presentations](content/history/talks.md)
+- [Independent references and recognition](content/history/external-recognition.md)
 
-## History & Changelog
+## Community and Contributions
 
-The evolution of this framework, including foundational research, publications, and community validation prior to this repository, is documented in the [CHANGELOG](CHANGELOG.md).
+GitHub is the canonical home for doctrine and specification changes. Community discussion and early design review may happen elsewhere, but accepted changes must be represented in the repository.
 
----
+Useful contributions include:
 
-## Community Discussion
+- operational failure reports and postmortems;
+- pattern proposals grounded in real systems;
+- critiques of terminology or control assumptions;
+- examples of escalation, fallback, and evaluation design;
+- corrections that improve provenance or precision.
 
-High-bandwidth discussion and design review happens in the Collaborative Dynamics Discord:
+See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-- **🧰 uncertainty-architecture** — community kitchen for UA
+## Authors and Maintainers
 
-GitHub is the canonical home for doctrine and changes; Discord is where ideas are stress-tested before becoming documents.
+### Vitalii Oborskyi — Creator and Lead Architect
 
----
+Focus: operational framing, governance, delivery systems, adoption scaffolding, and system-level control.
 
-## Authors & Architects
+- [LinkedIn](https://www.linkedin.com/in/vitaliioborskyi/)
+- [GitHub](https://github.com/oborskyivitalii)
 
-**Vitalii Oborskyi | The Structure & Governance**  *Creator & Lead Architect*
+### Sam “stunspot” Walker — Technical Co-Author
 
-**Focus:** operational framing, governance practices, adoption scaffolding, and system-level clarity.
+Focus: AI–code boundary placement, containment patterns, prompt-as-medium realism, and real-world failure modes.
 
-- Email: [oborskyivitalii@gmail.com](mailto:oborskyivitalii@gmail.com)
-- LinkedIn: [https://www.linkedin.com/in/vitaliioborskyi/](https://www.linkedin.com/in/vitaliioborskyi/)
-- GitHub: [https://github.com/oborskyivitalii](https://github.com/oborskyivitalii)
+Additional contributors and reviewers are credited as the work matures.
 
-**Sam “stunspot” Walker | Boundary Doctrine & System Patterns** _Technical Co-Author_ 
+## Advisory Context
 
-**Focus:** AI–code boundary placement, containment patterns, prompt-as-medium realism, and real-world failure modes.
+The project has benefited from public discussion and advisory relationships across engineering, project-management standards, academia, and AI delivery. These relationships are documented carefully in [`content/history/external-recognition.md`](content/history/external-recognition.md).
 
-- Email: [stunspot@collaborative-dynamics.com](mailto:stunspot@collaborative-dynamics.com)
-- Discord: [Stunspot Prompting](https://discord.gg/bGN45ynQ)(Channel: [🧰 uncertainty-architecture](https://discord.com/channels/1100933695986208849/1457956432287760605))
-
----
-
-## Advisory Board & Partnerships
-
-**Markus Kopko** – Strategic Advisor on Governance & Alignment
-
-Focus: Project management standards and organizational alignment.
-- LinkedIn: [https://www.linkedin.com/in/markuskleinpmp/](https://www.linkedin.com/in/markuskleinpmp/)
-
-**Otman Basir, Ph.D.** – Academic Advisor
-*Professor of Intelligent Systems, University of Waterloo*
-
-Author of the "Social Responsibility Stack" (SRS). Prof. Basir's research on Control-Theoretic AI Governance serves as the academic counterpart to the operational models built in Uncertainty Architecture. He acts as an Academic Advisor, providing guidance on bridging rigorous theory with practical engineering.
-- LinkedIn: [https://www.linkedin.com/in/otman-basir-ba1258178](https://www.linkedin.com/in/otman-basir-ba1258178)
-
-Additional contributors and reviewers will be credited as the work matures.
-
----
-
-## Roadmap & Contribution
-
-**Status:** Active Specification.
-
-- [x] **Phase 1: Concept Validation**(Completed)
-- [ ] **Phase 2: Spine** — scope, doctrine baseline, core distinctions (in progress)
-- [ ] **Phase 3: Patterns** — boundary patterns and failure modes
-- [ ] **Phase 4: Operating Model** — team practices that actually run
-- [ ] **Phase 5: Tooling (Optional)** — small utilities, only if they serve the doctrine
-
-The priority is durable clarity, not rapid tooling.
-
-**Contributing:** We especially welcome failure reports/post-mortems, boundary pattern proposals, critiques grounded in real systems and clarifications that improve precision. See `CONTRIBUTING.md`.
-
----
+An advisory relationship, recommendation, invited talk, repost, or conceptual convergence does not by itself imply adoption, certification, or organizational endorsement.
 
 ## How to Cite
 
@@ -299,19 +158,15 @@ The priority is durable clarity, not rapid tooling.
   title = {Uncertainty Architecture: An Operational Model for AI Governance},
   year = {2025},
   publisher = {GitHub},
-  howpublished = {\url{https://github.com/oborskyivitalii/uncertainty-architecture}}
+  howpublished = {\url{https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture}}
 }
 ```
-
----
 
 ## Licensing
 
 This repository uses a dual-license model:
 
-- Documentation and specifications are licensed under CC BY 4.0
-- Code and reference implementations are licensed under Apache 2.0
+- documentation and specifications: CC BY 4.0;
+- code and reference implementations: Apache 2.0.
 
-See `LICENSING.md` for details.
-
----
+See [`LICENSING.md`](LICENSING.md) for details.

--- a/content/history/talks.md
+++ b/content/history/talks.md
@@ -1,10 +1,38 @@
 # Talks and Presentations
 
-This document records public evidence of talks, workshops, and practitioner sessions involving Uncertainty Architecture.
+This document records public evidence of talks, workshops, and practitioner sessions in which Uncertainty Architecture was a substantive topic.
+
+It is not an event calendar, marketing log, or claim of organizational adoption. Private meetings, sales calls, unconfirmed invitations, and passing references are excluded.
+
+## June 2026 — Ukrainian Software Architecture Community (swarchua)
+
+Vitalii Oborskyi delivered a community-preview session for the Ukrainian software architecture community on **Uncertainty Architecture: Designing Non-Deterministic Systems**.
+
+The session examined why LLM-backed systems require a distinct engineering methodology rather than being treated only as an extension of conventional Machine Learning Engineering. The discussion focused on the change in the object being governed: core application behavior can now remain probabilistic at runtime.
+
+Topics included:
+
+- business risks and acceptable-deviation boundaries as inputs to requirements;
+- changes to Definition of Ready and Definition of Done for AI-enabled features;
+- statistical testing and risk thresholds;
+- semantic-drift monitoring, fallback paths, and kill switches;
+- Human-in-the-Loop as an architectural dependency;
+- changes to collaboration across architecture, QA, product, delivery, and development;
+- the role of an AI Control Plane in connecting stochastic components to deterministic business flows.
+
+A public recording was linked from the follow-up post.
+
+**What this establishes:** UA was presented and discussed in a public software-architecture community, with a recording and public follow-up material.
+
+**What it does not establish:** endorsement by the community as a whole, formal adoption by participating organizations, or independent validation of every UA claim.
+
+- [Session announcement](https://www.linkedin.com/posts/vitaliioborskyi_meet-activity-7471115607023947776-czyz/)
+- [Public follow-up: methodology and software-architecture framing](https://www.linkedin.com/posts/vitaliioborskyi_software-architecture-activity-7477274339411693569-dJhu/)
+- [Public follow-up: repository and recording](https://www.linkedin.com/posts/vitaliioborskyi_github-uncertaintyarchitecturegroupuncertainty-architecture-activity-7477275989761384448-k8J9/)
 
 ## July 2026 — Corning Incorporated Learn-AI-Palooza
 
-Vitalii Oborskyi joined an internal technical AI workshop at Corning Incorporated as an external speaker. The session focused on **Designing Non-Deterministic Systems** and used Uncertainty Architecture to examine how probabilistic model judgment changes software architecture, delivery assumptions, governance, and accountability.
+Vitalii Oborskyi joined an internal technical AI workshop for Corning Incorporated's Science & Technology team as an external speaker. The session focused on **Designing Non-Deterministic Systems** and used Uncertainty Architecture to examine how probabilistic model judgment changes software architecture, delivery assumptions, governance, and accountability.
 
 Topics included:
 
@@ -14,14 +42,19 @@ Topics included:
 - risks that emerge at the level of teams, operating models, ownership, and escalation rather than only in source code;
 - the need for sensing, correction, containment, and human decision authority.
 
-Rod Montgomery publicly described the session as one of the highlights of the event and emphasized that the most important risks of AI participation in execution and business logic often sit above the code layer.
+Rod Montgomery publicly described the session as one of the highlights of the event and emphasized that important risks of AI participation in execution and business logic often sit above the code layer.
 
 **What this establishes:** UA was presented and discussed with an enterprise technology audience, and the host independently documented the relevance of the system-level framing.
 
 **What it does not establish:** formal adoption of UA by Corning, approval by Corning leadership outside the workshop, or a public commercial engagement.
 
-- [Source: Rod Montgomery’s public post](https://www.linkedin.com/posts/roderickm_one-of-the-highlights-of-our-recent-learn-al-palooza-share-7480960627696558081-9L4z/)
+- [Source: Rod Montgomery's public post](https://www.linkedin.com/posts/roderickm_one-of-the-highlights-of-our-recent-learn-al-palooza-share-7480960627696558081-9L4z/)
 
 ## Entry criteria
 
-A talk should be added here when there is public evidence of the session and UA is a substantive topic rather than a passing reference. Private meetings, sales calls, and unconfirmed invitations should not be listed.
+A talk should be added here only when:
+
+1. there is public evidence that the session occurred;
+2. UA was a substantive topic rather than a passing reference;
+3. the description distinguishes presentation from endorsement, adoption, or certification;
+4. duplicate announcement and follow-up posts are grouped under one event rather than listed as separate talks.

--- a/content/history/timeline.md
+++ b/content/history/timeline.md
@@ -2,6 +2,8 @@
 
 This timeline records selected public milestones in the development of Uncertainty Architecture. It is not a release log; repository changes belong in `CHANGELOG.md`.
 
+The timeline links to the canonical research archive or public source rather than repeating full publication summaries.
+
 ## 2025
 
 ### July 29 — Initial public guide
@@ -66,9 +68,15 @@ The article introduced a bounded neuro-symbolic sensor pattern and extended UA i
 
 - [Source](https://www.linkedin.com/pulse/uncertainty-architecture-beyond-embeddings-semantic-oborskyi-1seuf/)
 
+### June 13 — Public software-architecture community session
+
+A community-preview session on **Designing Non-Deterministic Systems** was delivered for the Ukrainian software architecture community (swarchua). It examined changes to requirements, QA, DoR/DoD, release readiness, Human-in-the-Loop dependencies, and cross-functional control of probabilistic systems.
+
+The announcement, follow-up posts, and recording links are grouped as one event in the [talks record](talks.md#june-2026--ukrainian-software-architecture-community-swarchua).
+
 ### July 9 — Corning Learn-AI-Palooza public follow-up
 
-Rod Montgomery publicly documented Vitalii Oborskyi’s UA session at Corning Incorporated and highlighted the importance of system-level risks involving teams, operating models, governance, and accountability.
+Rod Montgomery publicly documented Vitalii Oborskyi’s UA session for Corning Incorporated's Science & Technology team and highlighted the importance of system-level risks involving teams, operating models, governance, and accountability.
 
 - [Source](https://www.linkedin.com/posts/roderickm_one-of-the-highlights-of-our-recent-learn-al-palooza-share-7480960627696558081-9L4z/)
 


### PR DESCRIPTION
## What changed

- refocused `README.md` as the canonical project entry point rather than a combined landing page, validation ledger, roadmap, and history document;
- removed duplicated roadmap detail and historical validation claims from the README, replacing them with clear navigation to the canonical files;
- restricted `CHANGELOG.md` to repository and specification-artifact changes and removed the pre-repository publication timeline;
- added the June 2026 Ukrainian software architecture community session to the project timeline;
- expanded `content/history/talks.md` with the swarchua session and grouped its announcement, methodology follow-up, repository link, and recording follow-up as one event rather than multiple talks;
- tightened talk-entry criteria so presentations remain distinct from endorsement, adoption, and certification.

## Why

After PRs #4 and #5, the repository had the right canonical documents but still repeated the same material across `README.md`, `ROADMAP.md`, `CHANGELOG.md`, and `content/history/`.

This change gives each document one clear responsibility:

- `README.md` — what UA is and where to start;
- `ROADMAP.md` — current direction and future work;
- `CHANGELOG.md` — repository and specification changes;
- `content/research/` — research corpus and analysis;
- `content/history/` — publications, talks, milestones, and independent references.

## Duplication decisions

This PR deliberately does **not** add `impact.md`, `milestones.md`, `why-ua.md`, or a separate `evidence-policy.md`:

- the origin and mission already belong in the README and research corpus;
- milestones are adequately represented by the timeline;
- the evidence policy already exists in `content/history/README.md`;
- impact claims would substantially overlap with the external-recognition ledger.

## Scope boundaries

This PR does not change doctrine, patterns, AI Control Plane content, reference architectures, failure modes, research publication bodies, licensing, or the detailed roadmap.

## Validation

- compared the branch against current `main` after PRs #4 and #5 were merged;
- verified that only four documentation files changed;
- checked that the two newly supplied LinkedIn links are represented as companion evidence for one swarchua session rather than duplicated as separate events;
- preserved the distinction between self-authored talk evidence and independent external recognition.