### PR TITLE
Add public stress tests and clarify README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,24 @@ Focus: AI–code boundary placement, containment patterns, prompt-as-medium real
 
 Additional contributors and reviewers are credited as the work matures.
 
+## Advisors
+
+### Markus Kopko — Strategic Advisor on Governance and Alignment
+
+Focus: project-management standards, organizational alignment, and the operationalization of AI governance.
+
+- [LinkedIn](https://www.linkedin.com/in/markuskleinpmp/)
+
+### Otman Basir, Ph.D. — Academic Advisor
+
+Professor of Intelligent Systems at the University of Waterloo and author of the Social Responsibility Stack. His role supports the connection between control-theoretic research and practical engineering governance.
+
+- [LinkedIn](https://www.linkedin.com/in/otman-basir-ba1258178)
+
+Advisory relationships are listed because they are part of the project's operating context. They do not imply institutional endorsement, certification, or formal adoption of UA.
+
+See [`content/history/external-recognition.md`](content/history/external-recognition.md) for supporting public evidence and precise claim boundaries.
+
 ## How to Cite
 
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ UA is not about eliminating uncertainty or pretending that AI can be made fully 
 
 The project is designed primarily for small and medium-sized engineering organizations that need practical control without building a large governance bureaucracy.
 
+## Start Here
+
+Choose the path that matches what you need:
+
+- **Understand the core concepts:** [`00-doctrine/`](00-doctrine/)
+- **Apply reusable engineering patterns:** [`01-patterns/`](01-patterns/)
+- **Design the control loop:** [`02-ai-control-plane/`](02-ai-control-plane/)
+- **Review concrete architectures:** [`03-reference-architectures/`](03-reference-architectures/)
+- **Study recurring failure modes:** [`04-failure-modes/`](04-failure-modes/)
+- **Trace the research behind the specification:** [`content/research/`](content/research/)
+- **Follow project history, talks, discussions, and external references:** [`content/history/`](content/history/)
+- **See what is being built next:** [`ROADMAP.md`](ROADMAP.md)
+
 ## The Core Shift
 
 Traditional software is mostly built from deterministic components and predefined execution paths. LLM-backed and agentic systems introduce components whose behavior remains probabilistic at runtime.
@@ -66,7 +79,7 @@ graph TD;
     F --> B;
 ```
 
-## Repository Structure
+## Repository Map
 
 ### Normative framework
 
@@ -76,11 +89,11 @@ graph TD;
 - [`03-reference-architectures/`](03-reference-architectures/) — worked architectural applications.
 - [`04-failure-modes/`](04-failure-modes/) — recurring technical and socio-technical failure modes.
 
-### Supporting knowledge
+### Supporting records
 
-- [`content/research/`](content/research/) — historical publications, research analysis, provenance, and research-to-framework traceability. Research material is non-normative until deliberately adopted into the specification.
-- [`content/history/`](content/history/) — project timeline, public talks, and independent references. This area records history without treating attention, discussion, or invited presentations as proof of adoption.
-- [`ROADMAP.md`](ROADMAP.md) — canonical project direction and future priorities.
+- [`content/research/`](content/research/) — publications, analysis, provenance, and research-to-framework traceability. Research remains non-normative until deliberately adopted.
+- [`content/history/`](content/history/) — project timeline, talks, public stress tests, and independent references.
+- [`ROADMAP.md`](ROADMAP.md) — canonical direction and future priorities.
 - [`CHANGELOG.md`](CHANGELOG.md) — repository and specification-artifact changes only.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution and review workflow.
 
@@ -98,34 +111,24 @@ The current priority is to consolidate the research corpus into a coherent frame
 
 Detailed status and sequencing are maintained in [`ROADMAP.md`](ROADMAP.md).
 
-## Research and Project History
+## Evidence and Project History
 
-The repository intentionally separates three different records:
+UA keeps different kinds of evidence separate:
 
-- **Research evolution** explains how ideas developed and where claims originated.
-- **Project history** records publications, talks, and independent interpretations.
-- **Changelog** records what changed in the repository and specification artifacts.
+- research explains where ideas and claims originated;
+- public discussions record critique, alternatives, and stress tests;
+- independent references record how third parties interpreted or used the concepts;
+- the changelog records changes to repository artifacts.
 
-This separation avoids using release history as a marketing timeline and prevents external references from being mistaken for technical validation.
+This prevents visibility, attention, recommendations, or invited talks from being mistaken for technical validation or formal adoption.
 
-Start here:
-
-- [Research Track](content/research/)
-- [Project timeline](content/history/timeline.md)
-- [Talks and presentations](content/history/talks.md)
-- [Independent references and recognition](content/history/external-recognition.md)
+See [`content/history/`](content/history/) for the evidence policy and historical records.
 
 ## Community and Contributions
 
 GitHub is the canonical home for doctrine and specification changes. Community discussion and early design review may happen elsewhere, but accepted changes must be represented in the repository.
 
-Useful contributions include:
-
-- operational failure reports and postmortems;
-- pattern proposals grounded in real systems;
-- critiques of terminology or control assumptions;
-- examples of escalation, fallback, and evaluation design;
-- corrections that improve provenance or precision.
+Useful contributions include operational failure reports, pattern proposals, critiques of terminology or control assumptions, examples of escalation and evaluation design, and provenance corrections.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
@@ -143,12 +146,6 @@ Focus: operational framing, governance, delivery systems, adoption scaffolding, 
 Focus: AI–code boundary placement, containment patterns, prompt-as-medium realism, and real-world failure modes.
 
 Additional contributors and reviewers are credited as the work matures.
-
-## Advisory Context
-
-The project has benefited from public discussion and advisory relationships across engineering, project-management standards, academia, and AI delivery. These relationships are documented carefully in [`content/history/external-recognition.md`](content/history/external-recognition.md).
-
-An advisory relationship, recommendation, invited talk, repost, or conceptual convergence does not by itself imply adoption, certification, or organizational endorsement.
 
 ## How to Cite
 

--- a/content/history/README.md
+++ b/content/history/README.md
@@ -6,24 +6,26 @@ It is intentionally separate from:
 
 - the normative framework in `00-doctrine/`, `01-patterns/`, `02-ai-control-plane/`, `03-reference-architectures/`, and `04-failure-modes/`;
 - the research corpus and analyses in `content/research/`;
-- the repository release history in `CHANGELOG.md`.
+- the repository and specification change record in `CHANGELOG.md`.
 
-The material here records public milestones, talks, independent references, and third-party interpretations. Inclusion does **not** imply endorsement of every UA claim, formal adoption of the specification, partnership, or organizational approval unless a source explicitly states that.
+The material here records public milestones, talks, community discussions, independent references, and third-party interpretations. Inclusion does **not** imply endorsement of every UA claim, formal adoption of the specification, partnership, or organizational approval unless a source explicitly states that.
 
 ## Documents
 
 - [Project timeline](timeline.md) — selected milestones in the development of UA.
-- [Independent references and recognition](external-recognition.md) — public third-party references, interpretations, and contextual validation.
-- [Talks and presentations](talks.md) — public evidence of presentations and practitioner discussion.
+- [Talks and presentations](talks.md) — public evidence of presentations and practitioner sessions.
+- [Community discussions and public stress tests](community-discussions.md) — substantive public critique, alternatives, and questions that shaped the project.
+- [Independent references and recognition](external-recognition.md) — public third-party references, interpretations, and contextual recognition.
 
 ## Evidence policy
 
 Entries should:
 
 1. link to a public primary source where possible;
-2. distinguish a direct citation from a repost, comment, recommendation, advisory relationship, or invited talk;
+2. distinguish self-authored publication, public discussion, direct citation, repost, comment, recommendation, advisory relationship, and invited talk;
 3. summarize what the source actually establishes without inflating it into formal adoption;
-4. avoid using follower counts, impressions, reactions, or self-authored promotional claims as evidence of technical validity;
-5. record corrections when a source becomes unavailable or its meaning is disputed.
+4. preserve substantive criticism and alternative interpretations rather than presenting only favorable reactions;
+5. avoid using follower counts, impressions, views, shares, reactions, or upvote ratios as evidence of technical validity;
+6. record corrections when a source becomes unavailable or its meaning is disputed.
 
-A self-authored summary may be retained as a navigation aid, but it is not treated as independent evidence.
+A self-authored source may document a publication, talk, or public stress test, but it is not treated as independent recognition.

--- a/content/history/community-discussions.md
+++ b/content/history/community-discussions.md
@@ -1,0 +1,57 @@
+# Community Discussions and Public Stress Tests
+
+This document records substantive public discussions that influenced how Uncertainty Architecture was explained, challenged, or refined.
+
+These entries are not independent endorsements. They are evidence that UA claims were exposed to practitioner critique, alternative proposals, and questions in public technical communities.
+
+## December 2025 — AI engineering as control theory
+
+A discussion in `r/learndatascience` presented the early Actuators–Constraints–Sensors–Controller framing and argued that many AI stacks were operating as open-loop systems.
+
+The discussion is historically useful because it exposed several weaknesses in the early formulation:
+
+- the control-theory analogy was seen by some readers as too metaphorical and insufficiently technical;
+- participants asked for a clearer mapping between control-theory elements and concrete system components;
+- the role of the Controller required clarification, especially whether it was software, an LLM, or a socio-technical operating model;
+- latency, controller reliability, deterministic memory, and the cost of additional layers were raised as practical constraints;
+- the discussion reinforced the need for a concise specification rather than relying on long-form explanatory posts.
+
+The thread also records the project at an early stage, before the repository became the canonical public specification.
+
+**What this establishes:** the core UA thesis was publicly challenged and refined through practitioner discussion.
+
+**What it does not establish:** correctness, consensus, adoption, or scientific validation. Engagement statistics are not treated as technical evidence.
+
+- [Reddit discussion](https://www.reddit.com/r/learndatascience/comments/1pjxsb4/why_ai_engineering_is_actually_control_theory_and/)
+
+## June 2026 — The fallacy of agentic loops
+
+A discussion in `r/softwarearchitecture` challenged the idea that adding probabilistic agents around other probabilistic agents automatically creates control, governance, or reliable verification.
+
+The discussion developed several themes that align with the current UA direction:
+
+- an agentic loop needs an explicit control objective, trusted signals, authority, stop conditions, fallback paths, and accountable ownership;
+- deterministic and stochastic gates can coexist, but confidence produced by probabilistic checks is not the same as control;
+- plans, designs, code, tests, deployment evidence, and runtime signals can become verification surfaces across the delivery lifecycle;
+- agents should operate inside bounded delivery systems rather than infer architecture, intent, and constraints from incomplete context;
+- safe operating envelopes should vary by language, codebase maturity, task type, and risk level;
+- the hard problem is often organizational and SDLC-level, not merely the addition of another technical component.
+
+The thread also contains disagreement and alternative interpretations, including arguments that multi-agent checks can still improve probability of success and that formal planning or deterministic substrate design may address parts of the problem.
+
+**What this establishes:** UA-adjacent control questions generated a substantive software-architecture discussion with competing technical and operational viewpoints.
+
+**What it does not establish:** broad agreement with UA, proof that the proposed control model is complete, or validation of any specific implementation.
+
+- [Reddit discussion](https://www.reddit.com/r/softwarearchitecture/comments/1u5tjy8/reinventing_control_theory_one_feature_at_a_time/)
+
+## Entry criteria
+
+A discussion belongs here when:
+
+1. UA or a core UA thesis is a substantive topic;
+2. the discussion contains meaningful critique, alternatives, or operational questions;
+3. the source is publicly accessible;
+4. the summary distinguishes discussion from endorsement or adoption.
+
+View counts, upvote ratios, shares, awards, and reaction totals may be preserved in raw historical sources, but they are not used here as evidence of technical validity.

--- a/content/history/timeline.md
+++ b/content/history/timeline.md
@@ -34,6 +34,12 @@ The article established the Actuators–Sensors–Controller framing and positio
 
 - [Source](https://www.linkedin.com/pulse/uncertainty-architecture-why-ai-governance-actually-control-oborskyi-oqhpf/)
 
+### December — First public control-theory stress test
+
+The control-theory framing was discussed in `r/learndatascience`. The thread surfaced demands for a clearer technical mapping, challenged the early metaphors, and forced clarification of the Controller as a socio-technical operating model rather than another LLM.
+
+- [Community discussion record](community-discussions.md#december-2025--ai-engineering-as-control-theory)
+
 ## 2026
 
 ### April 29 — Independent operational interpretation
@@ -73,6 +79,12 @@ The article introduced a bounded neuro-symbolic sensor pattern and extended UA i
 A community-preview session on **Designing Non-Deterministic Systems** was delivered for the Ukrainian software architecture community (swarchua). It examined changes to requirements, QA, DoR/DoD, release readiness, Human-in-the-Loop dependencies, and cross-functional control of probabilistic systems.
 
 The announcement, follow-up posts, and recording links are grouped as one event in the [talks record](talks.md#june-2026--ukrainian-software-architecture-community-swarchua).
+
+### June — Agentic-loops practitioner discussion
+
+A discussion in `r/softwarearchitecture` tested the claim that nested probabilistic agents do not automatically create control. It developed questions around deterministic and stochastic gates, verification surfaces, safe operating envelopes, SDLC design, and ownership of the surrounding control system.
+
+- [Community discussion record](community-discussions.md#june-2026--the-fallacy-of-agentic-loops)
 
 ### July 9 — Corning Learn-AI-Palooza public follow-up
 


### PR DESCRIPTION
## What changed

- added `content/history/community-discussions.md` as the canonical record for substantive public stress tests and practitioner discussions;
- documented the December 2025 `r/learndatascience` control-theory discussion, including the technical and communication weaknesses it exposed in the early UA formulation;
- documented the June 2026 `r/softwarearchitecture` discussion on the fallacy of agentic loops, including competing interpretations and alternative technical directions;
- added both discussions to the project timeline without treating them as independent recognition;
- updated the history evidence policy to distinguish self-authored discussion, independent reference, invited talk, and adoption;
- restructured the root README around explicit reader paths and removed duplicated navigation and advisory material.

## Why

The Reddit threads do not belong in `external-recognition.md`: they are self-authored public discussions, not third-party citations or endorsements. They also do not belong in the research publication archive because the threads are conversational stress tests rather than durable research artifacts.

A dedicated community-discussion record preserves their real value: public critique, alternative proposals, and evidence of how the project framing evolved.

The README already had the right content after PR #6, but the entry path still appeared after the introductory explanation. This PR moves task-oriented navigation near the top, consolidates historical evidence guidance, and makes the distinction between normative framework, supporting records, and operational assets easier to scan.

## Evidence boundaries

This PR explicitly avoids using views, shares, upvote ratios, or comments as technical validation. It also preserves critical and dissenting responses rather than presenting the threads as favorable social proof.

## Scope boundaries

This PR does not modify doctrine, patterns, AI Control Plane content, failure modes, research publication bodies, ROADMAP, CHANGELOG, licensing, or contributor governance.

## Validation

- compared against current `main` after PR #6 was merged;
- verified that each Reddit thread has one canonical location;
- verified that no content was duplicated into `external-recognition.md` or `content/research/`;
- limited the change to four documentation files;
- preserved the root README as a concise project entry point rather than a history or evidence ledger.