### PR TITLE
Normalize specification module entry points

### DIFF
--- a/00-doctrine/README.md
+++ b/00-doctrine/README.md
@@ -1,14 +1,50 @@
-# Core Doctrine & Theory
+# Core Doctrine
 
+**Status:** Draft normative  
+**Role:** Foundational vocabulary and architectural distinctions
 
-This directory contains the conceptual and doctrinal core of the project.
+## Purpose
 
-Here we define:
-- What LLM-based systems are operationally
-- Why AI systems are open, non-deterministic systems
-- Why judgment cannot be reduced to code
-- Why metrics alone cannot provide control
-- Why interfaces matter more than models
+This module defines the conceptual foundation used throughout Uncertainty Architecture (UA). It establishes how to reason about **Thinking Systems**: software systems whose runtime behavior depends partly on probabilistic model judgment while consequential boundaries, responsibilities, and corrective mechanisms remain explicit.
 
-This is the shared mental model that keeps the system honest.
+The doctrine provides the shared mental model needed to discuss uncertainty without treating model behavior as either ordinary deterministic code or uncontrollable magic.
 
+## Defines
+
+This module defines or develops the foundational distinctions behind:
+
+- Thinking Systems;
+- deterministic control logic and model judgment;
+- the boundary between probabilistic behavior and deterministic system responsibilities;
+- open and non-deterministic operating conditions;
+- uncertainty containment rather than uncertainty elimination;
+- the limits of metrics without decision authority and corrective action;
+- the architectural importance of interfaces, invariants, feedback, and human authority.
+
+## Does not define
+
+This module does not prescribe:
+
+- a specific model, vendor, framework, or implementation stack;
+- a complete runtime control-plane design;
+- one universal set of controls or evaluation thresholds;
+- a mandatory organizational structure;
+- a certification or conformance program.
+
+## Key concepts
+
+- **Thinking System** — a software system in which part of the runtime path or decision process is produced through model-mediated judgment.
+- **Deterministic Core** — rules, invariants, permissions, data handling, and other responsibilities that must remain explicitly controlled.
+- **Model Judgment** — interpretation, synthesis, classification, generation, or action selection under uncertainty.
+- **Uncertainty Boundary** — the interface at which deterministic responsibilities meet probabilistic judgment.
+- **Containment** — limiting where uncertainty may propagate and defining what happens when behavior leaves acceptable bounds.
+
+Canonical wording will be consolidated in the project glossary. Until then, these descriptions establish the intended conceptual direction rather than final term-level conformance language.
+
+## Relationships
+
+- [`01-patterns/`](../01-patterns/) translates doctrine into reusable architectural responses.
+- [`02-ai-control-plane/`](../02-ai-control-plane/) defines the capabilities used to constrain, observe, and correct model-mediated behavior.
+- [`03-reference-architectures/`](../03-reference-architectures/) demonstrates possible compositions of the doctrine and patterns.
+- [`04-failure-modes/`](../04-failure-modes/) records recurring mechanisms through which these distinctions are violated or lost.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines the status and normative boundary of this module.

--- a/01-patterns/README.md
+++ b/01-patterns/README.md
@@ -1,11 +1,64 @@
-# Interface & Control Patterns
+# Interface and Control Patterns
 
+**Status:** Draft normative  
+**Role:** Reusable architectural responses for recurring control problems
 
-Reusable patterns for managing the AI–code boundary.
+## Purpose
 
-Focuses on:
-- Judgment nodes vs deterministic control logic
-- Hard vs soft invariants
-- Containment of non-determinism
-- Procedural gasket patterns between code and models
+This module contains reusable patterns for engineering the boundary between deterministic software responsibilities and probabilistic model judgment in Thinking Systems.
 
+Patterns turn UA doctrine into reviewable design choices. They describe where uncertainty may enter a workflow, how it is bounded, what evidence is produced, and how failure is contained or escalated.
+
+## Defines
+
+This module defines or develops patterns for:
+
+- separating judgment nodes from deterministic control logic;
+- preserving hard invariants around probabilistic behavior;
+- expressing soft constraints without confusing them with guarantees;
+- validating, gating, retrying, containing, or escalating model outputs;
+- maintaining traceability across model-mediated decisions;
+- creating procedural interfaces between code, models, tools, and human authority.
+
+## Does not define
+
+This module does not prescribe:
+
+- one universal workflow or orchestration framework;
+- a fixed implementation technology;
+- identical controls for systems with different consequences and operating contexts;
+- reference architectures as mandatory deployment topologies;
+- universal numerical thresholds for acceptable behavior.
+
+## Pattern expectations
+
+A mature UA pattern should make the following explicit:
+
+1. the recurring problem and operating context;
+2. the uncertainty or failure mechanism being addressed;
+3. the deterministic responsibilities that must remain intact;
+4. the proposed control structure;
+5. the evidence or signals needed to operate it;
+6. escalation, fallback, or recovery behavior;
+7. important trade-offs and known limits.
+
+Examples attached to a pattern are informative unless explicitly classified otherwise.
+
+## Key concepts
+
+- judgment node;
+- deterministic boundary;
+- hard invariant;
+- soft constraint;
+- procedural interface;
+- validation gate;
+- fallback and escalation;
+- containment of non-determinism.
+
+## Relationships
+
+- [`00-doctrine/`](../00-doctrine/) provides the foundational distinctions used by the patterns.
+- [`02-ai-control-plane/`](../02-ai-control-plane/) provides the control capabilities through which patterns are operated.
+- [`03-reference-architectures/`](../03-reference-architectures/) demonstrates possible combinations of patterns.
+- [`04-failure-modes/`](../04-failure-modes/) provides the failure mechanisms that patterns should mitigate.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines the status and normative boundary of this module.

--- a/02-ai-control-plane/README.md
+++ b/02-ai-control-plane/README.md
@@ -1,20 +1,65 @@
 # The AI Control Plane
 
-> **Architecture:** Closed-Loop System
-> **Objective:** Stabilize Probabilistic Behavior
+**Status:** Draft normative  
+**Role:** Capability model for constraining, observing, and correcting model-mediated behavior
 
-This directory contains the reference implementation of the **Uncertainty Architecture** control loop.
+## Purpose
 
-Unlike traditional software, where logic is deterministic ($y = f(x)$), AI systems are probabilistic ($y \sim P(y|x)$). To build reliable software on top of unreliable components, we cannot just "write code." We must engineer a control system.
+This module defines the control capabilities required to operate Thinking Systems as closed-loop systems rather than open-loop model integrations.
 
-## The Architecture: The Control Loop
+The AI Control Plane is not necessarily a standalone product or infrastructure layer. Its responsibilities may be distributed across application code, platform services, evaluation systems, human workflows, release processes, and governance mechanisms.
 
-The Control Plane consists of three distinct subsystems that work in a continuous cycle:
+## Defines
+
+This module defines or develops:
+
+- **Actuators** that shape or constrain model-mediated behavior;
+- **Sensors** that observe outputs, outcomes, drift, incidents, and operating conditions;
+- **Controllers** that interpret evidence and authorize corrective action;
+- feedback loops connecting observation to controlled change;
+- release, escalation, rollback, containment, and shutdown responsibilities;
+- traceability between evidence, decisions, and system changes.
+
+## Does not define
+
+This module does not prescribe:
+
+- one centralized control-plane service;
+- a specific model, framework, vendor, or deployment topology;
+- universal quality, safety, latency, cost, or autonomy thresholds;
+- fully automated control in contexts that require human authority;
+- model quality as a substitute for system-level control.
+
+## Key concepts
+
+- actuator;
+- sensor;
+- controller;
+- error or deviation signal;
+- target operating envelope;
+- release gate;
+- escalation and human authority;
+- rollback, containment, and shutdown;
+- feedback latency and control cadence.
+
+## Relationships
+
+- [`00-doctrine/`](../00-doctrine/) explains why probabilistic judgment requires explicit boundaries and feedback.
+- [`01-patterns/`](../01-patterns/) describes reusable ways to implement control responsibilities.
+- [`03-reference-architectures/`](../03-reference-architectures/) demonstrates possible distributions of control-plane capabilities.
+- [`04-failure-modes/`](../04-failure-modes/) identifies deviations and control failures the plane must detect or mitigate.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines the status and normative boundary of this module.
+
+## Control-loop architecture
 
 ```mermaid
 graph LR
-    A[Input] --> B(Actuators)
-    B --> C[Output]
-    C --> D(Sensors)
-    D -->|Error Signal| E(Controller)
-    E -->|Update Config| B
+    A[Input and Operating Context] --> B[Actuators and Constraints]
+    B --> C[Model-Mediated Behavior]
+    C --> D[Sensors and Evidence]
+    D -->|Deviation / Outcome Signal| E[Controller]
+    E -->|Corrective Decision| B
+    E -->|Escalate / Roll Back / Stop| F[Containment and Human Authority]
+```
+
+A functioning loop requires more than telemetry. Observation becomes control only when evidence is connected to decision rights and a mechanism capable of changing, containing, or stopping behavior.

--- a/03-reference-architectures/README.md
+++ b/03-reference-architectures/README.md
@@ -1,11 +1,54 @@
-# Reference Architecture
+# Reference Architectures
 
-This directory contains concrete reference architectures that demonstrate
-how the principles of Uncertainty Architecture can be applied in real systems.
+**Status:** Reference  
+**Role:** Concrete, non-prescriptive compositions of UA concepts and patterns
 
-These architectures are examples, not prescriptions.
-They show how to separate deterministic control logic
-from probabilistic judgment components in production.
+## Purpose
 
-Indranet is one implementation of these patterns,
-not the standard itself.
+This module contains concrete architectures that demonstrate how Uncertainty Architecture may be applied in real systems.
+
+Reference architectures make abstract responsibilities visible: where model judgment occurs, which deterministic boundaries surround it, how evidence is collected, who or what controls change, and how failure is contained.
+
+## Defines
+
+This module provides:
+
+- worked architectural compositions;
+- examples of deterministic and probabilistic responsibility boundaries;
+- possible distributions of AI Control Plane capabilities;
+- implementation-oriented demonstrations of UA patterns;
+- explicit assumptions, trade-offs, and unresolved design choices where available.
+
+## Does not define
+
+This module does not prescribe:
+
+- a mandatory system topology;
+- one preferred vendor, framework, or orchestration platform;
+- universal controls for every risk class or operating context;
+- conformance merely through copying an example;
+- any reference implementation as the UA standard itself.
+
+## Reference expectations
+
+A mature reference architecture should identify:
+
+1. the operating context and intended outcomes;
+2. where probabilistic judgment occurs;
+3. the deterministic boundaries and invariants;
+4. relevant actuators, sensors, and controllers;
+5. decision authority and human involvement;
+6. failure, escalation, rollback, and containment paths;
+7. known assumptions, limits, and trade-offs.
+
+## Current scope
+
+Indranet is one implementation-oriented expression of UA concepts. It is a reference, not the specification itself, and its design choices are not automatically normative.
+
+## Relationships
+
+- [`00-doctrine/`](../00-doctrine/) provides the conceptual foundation.
+- [`01-patterns/`](../01-patterns/) provides reusable architectural building blocks.
+- [`02-ai-control-plane/`](../02-ai-control-plane/) provides the control capability model used in compositions.
+- [`04-failure-modes/`](../04-failure-modes/) provides failure mechanisms that references should address explicitly.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines why reference architectures remain outside the mandatory topology of the specification.

--- a/04-failure-modes/README.md
+++ b/04-failure-modes/README.md
@@ -1,36 +1,99 @@
-# Failure Modes & Anti-Patterns
+# Failure Modes and Anti-Patterns
 
-> **Objective:** Taxonomy of Entropy
-> **Motto:** "We learn from the crash, not the flight."
+**Status:** Draft normative taxonomy; examples are informative  
+**Role:** Recurring mechanisms through which control is lost in Thinking Systems
 
-This directory documents the specific ways AI-integrated systems fail. Unlike traditional software bugs (which are logical errors), AI failures are often **probabilistic drifts** or **boundary breaches**.
+## Purpose
 
-We categorize failures into three distinct domains:
+This module documents recurring ways in which systems containing model-mediated judgment lose structural, semantic, operational, or organizational control.
 
-## 1. Syntactic Entropy (The Structure Breaks)
-Failures where the model output violates the technical contract required by the host system.
-*   **Malformed JSON:** The model returns text or Markdown instead of a structured object.
-*   **Type Hallucination:** Returning a string where an integer was expected.
-*   **Infinite Loops:** The model gets stuck in a repetition cycle.
-*   **Context Overflow:** Input exceeds the model's window, causing truncation.
+Traditional software failures often arise from explicit logical defects. Thinking Systems also fail through probabilistic drift, boundary breaches, weak evidence, delayed feedback, unclear authority, and controls that exist on paper but cannot change runtime behavior.
 
-> *Mitigation:* Solved by **Actuators** (Strict Schemas, Pydantic, Retry Logic).
+## Defines
 
-## 2. Semantic Entropy (The Meaning Breaks)
-Failures where the output is technically valid (passes JSON validation) but functionally wrong, dangerous, or useless.
-*   **Hallucination:** Confidently stating false facts.
-*   **Tone Drift:** A support bot becoming aggressive, overly casual, or robotic.
-*   **Refusal/Over-safety:** The model refuses a valid business request due to generic safety filters.
-*   **Instruction Ignoring:** The model ignores negative constraints ("Do not mention X").
+This module defines or develops a taxonomy of:
 
-> *Mitigation:* Solved by **Sensors** (Evals, Golden Sets) and **Controller** (Human Review).
+- structural and syntactic failures;
+- semantic and outcome failures;
+- runtime and feedback-loop failures;
+- architectural boundary failures;
+- governance and decision-authority failures;
+- anti-patterns that treat probabilistic behavior as deterministic code.
 
-## 3. Process Anti-Patterns (The Governance Breaks)
-Failures caused by treating probabilistic components as deterministic code.
-*   **The "Vibe Check" Release:** Deploying a prompt because it "looked good" on 3 random examples.
-*   **Magic Strings:** Hardcoding prompts deep inside Python functions instead of a Registry.
-*   **Open Loop Deployment:** Running a model without any feedback mechanism to detect drift over time.
-*   **The "Perfect Prompt" Fallacy:** Wasting weeks trying to engineer a prompt that works 100% of the time (instead of building error handling).
+## Does not define
+
+This module does not provide:
+
+- an exhaustive catalogue of every possible incident;
+- one universal severity model;
+- a guarantee that a single control eliminates a failure mode;
+- mandatory implementation technology;
+- post-mortems as normative requirements.
+
+Individual examples are illustrative. Mitigation normally requires a combination of boundaries, actuators, sensors, controller decisions, and operating procedures proportional to the system's consequences and context.
+
+## Key concepts
+
+- syntactic entropy;
+- semantic entropy;
+- probabilistic drift;
+- boundary breach;
+- open-loop deployment;
+- evidence failure;
+- controller or authority failure;
+- containment and recovery failure.
+
+## Relationships
+
+- [`00-doctrine/`](../00-doctrine/) provides the distinctions needed to explain why these failures occur.
+- [`01-patterns/`](../01-patterns/) contains reusable responses to recurring failure mechanisms.
+- [`02-ai-control-plane/`](../02-ai-control-plane/) provides the capabilities used to detect, interpret, and correct deviations.
+- [`03-reference-architectures/`](../03-reference-architectures/) demonstrates how failure handling may be composed in concrete systems.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines the status and normative boundary of this taxonomy.
+
+## Initial taxonomy
+
+### 1. Syntactic entropy — the structure breaks
+
+The model output violates a technical contract required by the surrounding system.
+
+Illustrative examples:
+
+- malformed structured output;
+- incorrect field or value types;
+- repetition or non-terminating behavior;
+- context overflow or truncation;
+- outputs that cannot be parsed, validated, or safely executed.
+
+Typical controls include strict schemas, validation, bounded retries, deterministic parsing, execution limits, and explicit fallback paths.
+
+### 2. Semantic entropy — the meaning breaks
+
+The output is technically valid but functionally wrong, unsafe, misleading, or unsuitable for the operating context.
+
+Illustrative examples:
+
+- unsupported or false claims;
+- tone or policy drift;
+- unjustified refusal or over-restriction;
+- ignored instructions or negative constraints;
+- valid-looking actions that violate business intent.
+
+Typical controls include evaluations, golden scenarios, runtime outcome signals, policy checks, human review, escalation, and controller-authorized changes.
+
+### 3. Process and governance anti-patterns — the control system breaks
+
+The organization treats probabilistic behavior as if ordinary development and release practices were sufficient.
+
+Illustrative examples:
+
+- **Vibe-check release:** deployment based on a few favorable examples rather than risk-derived evidence;
+- **Hidden behavior configuration:** prompts, policies, or model settings embedded without ownership or traceability;
+- **Open-loop deployment:** operation without meaningful feedback or a mechanism for corrective action;
+- **Perfect-prompt fallacy:** attempting to eliminate uncertainty through prompting instead of engineering containment and recovery;
+- **Telemetry without authority:** collecting metrics without assigning who may intervene or change the system;
+- **Human-in-the-loop theatre:** nominal approval steps without adequate context, time, competence, or real decision power.
 
 ## Contribution
-This section is a library of "Battle Scars." We encourage submitting **Post-Mortems** of real-world failures to help the community build better containment strategies.
+
+Operational failure reports and post-mortems are valuable inputs to this module. Contributions should distinguish observed evidence from interpretation, identify operating context and consequences, and avoid presenting a single incident as a universal rule.


### PR DESCRIPTION
## What changed

Normalized the entry-point README for each primary UA module:

- `00-doctrine/`
- `01-patterns/`
- `02-ai-control-plane/`
- `03-reference-architectures/`
- `04-failure-modes/`

Each module now declares:

- document status and architectural role;
- purpose;
- what the module defines;
- what it deliberately does not define;
- key concepts or expectations;
- relationships to the other specification modules and `SPECIFICATION.md`.

Additional changes:

- introduced **Thinking Systems** as the current conceptual term in the normalized module language;
- did not reintroduce the historical `Behavioral Applications` label;
- reframed the AI Control Plane as a distributed capability model rather than a reference implementation or mandatory standalone layer;
- retained and expanded the control-loop diagram;
- clarified that reference architectures are non-prescriptive;
- separated the normative failure-mode taxonomy from informative examples;
- replaced overly strong single-control mitigation claims with system-level combinations of boundaries, actuators, sensors, controller decisions, escalation, and recovery.

## Why

The module entry points previously used different structures and levels of detail. Some read like short folder notes, one read like an article, and another combined taxonomy, examples, and contribution guidance without a clear status boundary.

A common module contract makes the repository read as one specification rather than a collection of documents from different stages of the project.

## Terminology note

`Thinking Systems` is used as the current term. Canonical definitions and migration from older terminology will be handled in the planned glossary/terminology pass rather than scattered across this structural PR.

## Dependency

This is a stacked draft PR based on `agent/readme-navigation` (PR #10), which is itself based on the specification-spine PR #9.

Expected merge order:

1. PR #9 — specification spine;
2. PR #10 — README landing page;
3. this PR — normalized module entry points.

## Validation

- compared directly against `agent/readme-navigation`;
- branch is five commits ahead and zero commits behind its base;
- only the five module README files change;
- all module relationships use repository-relative links;
- no `Behavioral Applications` terminology was introduced.