### PR TITLE
Adopt Thinking Systems terminology across the repository

### DIFF
--- a/00-doctrine/README.md
+++ b/00-doctrine/README.md
@@ -1,14 +1,50 @@
-# Core Doctrine & Theory
+# Core Doctrine
 
+**Status:** Draft normative  
+**Role:** Foundational vocabulary and architectural distinctions
 
-This directory contains the conceptual and doctrinal core of the project.
+## Purpose
 
-Here we define:
-- What LLM-based systems are operationally
-- Why AI systems are open, non-deterministic systems
-- Why judgment cannot be reduced to code
-- Why metrics alone cannot provide control
-- Why interfaces matter more than models
+This module defines the conceptual foundation used throughout Uncertainty Architecture (UA). It establishes how to reason about **Thinking Systems**: software systems whose runtime behavior depends partly on probabilistic model judgment while consequential boundaries, responsibilities, and corrective mechanisms remain explicit.
 
-This is the shared mental model that keeps the system honest.
+The doctrine provides the shared mental model needed to discuss uncertainty without treating model behavior as either ordinary deterministic code or uncontrollable magic.
 
+## Defines
+
+This module defines or develops the foundational distinctions behind:
+
+- Thinking Systems;
+- deterministic control logic and model judgment;
+- the boundary between probabilistic behavior and deterministic system responsibilities;
+- open and non-deterministic operating conditions;
+- uncertainty containment rather than uncertainty elimination;
+- the limits of metrics without decision authority and corrective action;
+- the architectural importance of interfaces, invariants, feedback, and human authority.
+
+## Does not define
+
+This module does not prescribe:
+
+- a specific model, vendor, framework, or implementation stack;
+- a complete runtime control-plane design;
+- one universal set of controls or evaluation thresholds;
+- a mandatory organizational structure;
+- a certification or conformance program.
+
+## Key concepts
+
+- **Thinking System** — a software system in which part of the runtime path or decision process is produced through model-mediated judgment.
+- **Deterministic Core** — rules, invariants, permissions, data handling, and other responsibilities that must remain explicitly controlled.
+- **Model Judgment** — interpretation, synthesis, classification, generation, or action selection under uncertainty.
+- **Uncertainty Boundary** — the interface at which deterministic responsibilities meet probabilistic judgment.
+- **Containment** — limiting where uncertainty may propagate and defining what happens when behavior leaves acceptable bounds.
+
+Canonical wording will be consolidated in the project glossary. Until then, these descriptions establish the intended conceptual direction rather than final term-level conformance language.
+
+## Relationships
+
+- [`01-patterns/`](../01-patterns/) translates doctrine into reusable architectural responses.
+- [`02-ai-control-plane/`](../02-ai-control-plane/) defines the capabilities used to constrain, observe, and correct model-mediated behavior.
+- [`03-reference-architectures/`](../03-reference-architectures/) demonstrates possible compositions of the doctrine and patterns.
+- [`04-failure-modes/`](../04-failure-modes/) records recurring mechanisms through which these distinctions are violated or lost.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines the status and normative boundary of this module.

--- a/01-patterns/README.md
+++ b/01-patterns/README.md
@@ -1,11 +1,64 @@
-# Interface & Control Patterns
+# Interface and Control Patterns
 
+**Status:** Draft normative  
+**Role:** Reusable architectural responses for recurring control problems
 
-Reusable patterns for managing the AI–code boundary.
+## Purpose
 
-Focuses on:
-- Judgment nodes vs deterministic control logic
-- Hard vs soft invariants
-- Containment of non-determinism
-- Procedural gasket patterns between code and models
+This module contains reusable patterns for engineering the boundary between deterministic software responsibilities and probabilistic model judgment in Thinking Systems.
 
+Patterns turn UA doctrine into reviewable design choices. They describe where uncertainty may enter a workflow, how it is bounded, what evidence is produced, and how failure is contained or escalated.
+
+## Defines
+
+This module defines or develops patterns for:
+
+- separating judgment nodes from deterministic control logic;
+- preserving hard invariants around probabilistic behavior;
+- expressing soft constraints without confusing them with guarantees;
+- validating, gating, retrying, containing, or escalating model outputs;
+- maintaining traceability across model-mediated decisions;
+- creating procedural interfaces between code, models, tools, and human authority.
+
+## Does not define
+
+This module does not prescribe:
+
+- one universal workflow or orchestration framework;
+- a fixed implementation technology;
+- identical controls for systems with different consequences and operating contexts;
+- reference architectures as mandatory deployment topologies;
+- universal numerical thresholds for acceptable behavior.
+
+## Pattern expectations
+
+A mature UA pattern should make the following explicit:
+
+1. the recurring problem and operating context;
+2. the uncertainty or failure mechanism being addressed;
+3. the deterministic responsibilities that must remain intact;
+4. the proposed control structure;
+5. the evidence or signals needed to operate it;
+6. escalation, fallback, or recovery behavior;
+7. important trade-offs and known limits.
+
+Examples attached to a pattern are informative unless explicitly classified otherwise.
+
+## Key concepts
+
+- judgment node;
+- deterministic boundary;
+- hard invariant;
+- soft constraint;
+- procedural interface;
+- validation gate;
+- fallback and escalation;
+- containment of non-determinism.
+
+## Relationships
+
+- [`00-doctrine/`](../00-doctrine/) provides the foundational distinctions used by the patterns.
+- [`02-ai-control-plane/`](../02-ai-control-plane/) provides the control capabilities through which patterns are operated.
+- [`03-reference-architectures/`](../03-reference-architectures/) demonstrates possible combinations of patterns.
+- [`04-failure-modes/`](../04-failure-modes/) provides the failure mechanisms that patterns should mitigate.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines the status and normative boundary of this module.

--- a/02-ai-control-plane/README.md
+++ b/02-ai-control-plane/README.md
@@ -1,20 +1,65 @@
 # The AI Control Plane
 
-> **Architecture:** Closed-Loop System
-> **Objective:** Stabilize Probabilistic Behavior
+**Status:** Draft normative  
+**Role:** Capability model for constraining, observing, and correcting model-mediated behavior
 
-This directory contains the reference implementation of the **Uncertainty Architecture** control loop.
+## Purpose
 
-Unlike traditional software, where logic is deterministic ($y = f(x)$), AI systems are probabilistic ($y \sim P(y|x)$). To build reliable software on top of unreliable components, we cannot just "write code." We must engineer a control system.
+This module defines the control capabilities required to operate Thinking Systems as closed-loop systems rather than open-loop model integrations.
 
-## The Architecture: The Control Loop
+The AI Control Plane is not necessarily a standalone product or infrastructure layer. Its responsibilities may be distributed across application code, platform services, evaluation systems, human workflows, release processes, and governance mechanisms.
 
-The Control Plane consists of three distinct subsystems that work in a continuous cycle:
+## Defines
+
+This module defines or develops:
+
+- **Actuators** that shape or constrain model-mediated behavior;
+- **Sensors** that observe outputs, outcomes, drift, incidents, and operating conditions;
+- **Controllers** that interpret evidence and authorize corrective action;
+- feedback loops connecting observation to controlled change;
+- release, escalation, rollback, containment, and shutdown responsibilities;
+- traceability between evidence, decisions, and system changes.
+
+## Does not define
+
+This module does not prescribe:
+
+- one centralized control-plane service;
+- a specific model, framework, vendor, or deployment topology;
+- universal quality, safety, latency, cost, or autonomy thresholds;
+- fully automated control in contexts that require human authority;
+- model quality as a substitute for system-level control.
+
+## Key concepts
+
+- actuator;
+- sensor;
+- controller;
+- error or deviation signal;
+- target operating envelope;
+- release gate;
+- escalation and human authority;
+- rollback, containment, and shutdown;
+- feedback latency and control cadence.
+
+## Relationships
+
+- [`00-doctrine/`](../00-doctrine/) explains why probabilistic judgment requires explicit boundaries and feedback.
+- [`01-patterns/`](../01-patterns/) describes reusable ways to implement control responsibilities.
+- [`03-reference-architectures/`](../03-reference-architectures/) demonstrates possible distributions of control-plane capabilities.
+- [`04-failure-modes/`](../04-failure-modes/) identifies deviations and control failures the plane must detect or mitigate.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines the status and normative boundary of this module.
+
+## Control-loop architecture
 
 ```mermaid
 graph LR
-    A[Input] --> B(Actuators)
-    B --> C[Output]
-    C --> D(Sensors)
-    D -->|Error Signal| E(Controller)
-    E -->|Update Config| B
+    A[Input and Operating Context] --> B[Actuators and Constraints]
+    B --> C[Model-Mediated Behavior]
+    C --> D[Sensors and Evidence]
+    D -->|Deviation / Outcome Signal| E[Controller]
+    E -->|Corrective Decision| B
+    E -->|Escalate / Roll Back / Stop| F[Containment and Human Authority]
+```
+
+A functioning loop requires more than telemetry. Observation becomes control only when evidence is connected to decision rights and a mechanism capable of changing, containing, or stopping behavior.

--- a/03-reference-architectures/README.md
+++ b/03-reference-architectures/README.md
@@ -1,11 +1,54 @@
-# Reference Architecture
+# Reference Architectures
 
-This directory contains concrete reference architectures that demonstrate
-how the principles of Uncertainty Architecture can be applied in real systems.
+**Status:** Reference  
+**Role:** Concrete, non-prescriptive compositions of UA concepts and patterns
 
-These architectures are examples, not prescriptions.
-They show how to separate deterministic control logic
-from probabilistic judgment components in production.
+## Purpose
 
-Indranet is one implementation of these patterns,
-not the standard itself.
+This module contains concrete architectures that demonstrate how Uncertainty Architecture may be applied in real systems.
+
+Reference architectures make abstract responsibilities visible: where model judgment occurs, which deterministic boundaries surround it, how evidence is collected, who or what controls change, and how failure is contained.
+
+## Defines
+
+This module provides:
+
+- worked architectural compositions;
+- examples of deterministic and probabilistic responsibility boundaries;
+- possible distributions of AI Control Plane capabilities;
+- implementation-oriented demonstrations of UA patterns;
+- explicit assumptions, trade-offs, and unresolved design choices where available.
+
+## Does not define
+
+This module does not prescribe:
+
+- a mandatory system topology;
+- one preferred vendor, framework, or orchestration platform;
+- universal controls for every risk class or operating context;
+- conformance merely through copying an example;
+- any reference implementation as the UA standard itself.
+
+## Reference expectations
+
+A mature reference architecture should identify:
+
+1. the operating context and intended outcomes;
+2. where probabilistic judgment occurs;
+3. the deterministic boundaries and invariants;
+4. relevant actuators, sensors, and controllers;
+5. decision authority and human involvement;
+6. failure, escalation, rollback, and containment paths;
+7. known assumptions, limits, and trade-offs.
+
+## Current scope
+
+Indranet is one implementation-oriented expression of UA concepts. It is a reference, not the specification itself, and its design choices are not automatically normative.
+
+## Relationships
+
+- [`00-doctrine/`](../00-doctrine/) provides the conceptual foundation.
+- [`01-patterns/`](../01-patterns/) provides reusable architectural building blocks.
+- [`02-ai-control-plane/`](../02-ai-control-plane/) provides the control capability model used in compositions.
+- [`04-failure-modes/`](../04-failure-modes/) provides failure mechanisms that references should address explicitly.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines why reference architectures remain outside the mandatory topology of the specification.

--- a/04-failure-modes/README.md
+++ b/04-failure-modes/README.md
@@ -1,36 +1,99 @@
-# Failure Modes & Anti-Patterns
+# Failure Modes and Anti-Patterns
 
-> **Objective:** Taxonomy of Entropy
-> **Motto:** "We learn from the crash, not the flight."
+**Status:** Draft normative taxonomy; examples are informative  
+**Role:** Recurring mechanisms through which control is lost in Thinking Systems
 
-This directory documents the specific ways AI-integrated systems fail. Unlike traditional software bugs (which are logical errors), AI failures are often **probabilistic drifts** or **boundary breaches**.
+## Purpose
 
-We categorize failures into three distinct domains:
+This module documents recurring ways in which systems containing model-mediated judgment lose structural, semantic, operational, or organizational control.
 
-## 1. Syntactic Entropy (The Structure Breaks)
-Failures where the model output violates the technical contract required by the host system.
-*   **Malformed JSON:** The model returns text or Markdown instead of a structured object.
-*   **Type Hallucination:** Returning a string where an integer was expected.
-*   **Infinite Loops:** The model gets stuck in a repetition cycle.
-*   **Context Overflow:** Input exceeds the model's window, causing truncation.
+Traditional software failures often arise from explicit logical defects. Thinking Systems also fail through probabilistic drift, boundary breaches, weak evidence, delayed feedback, unclear authority, and controls that exist on paper but cannot change runtime behavior.
 
-> *Mitigation:* Solved by **Actuators** (Strict Schemas, Pydantic, Retry Logic).
+## Defines
 
-## 2. Semantic Entropy (The Meaning Breaks)
-Failures where the output is technically valid (passes JSON validation) but functionally wrong, dangerous, or useless.
-*   **Hallucination:** Confidently stating false facts.
-*   **Tone Drift:** A support bot becoming aggressive, overly casual, or robotic.
-*   **Refusal/Over-safety:** The model refuses a valid business request due to generic safety filters.
-*   **Instruction Ignoring:** The model ignores negative constraints ("Do not mention X").
+This module defines or develops a taxonomy of:
 
-> *Mitigation:* Solved by **Sensors** (Evals, Golden Sets) and **Controller** (Human Review).
+- structural and syntactic failures;
+- semantic and outcome failures;
+- runtime and feedback-loop failures;
+- architectural boundary failures;
+- governance and decision-authority failures;
+- anti-patterns that treat probabilistic behavior as deterministic code.
 
-## 3. Process Anti-Patterns (The Governance Breaks)
-Failures caused by treating probabilistic components as deterministic code.
-*   **The "Vibe Check" Release:** Deploying a prompt because it "looked good" on 3 random examples.
-*   **Magic Strings:** Hardcoding prompts deep inside Python functions instead of a Registry.
-*   **Open Loop Deployment:** Running a model without any feedback mechanism to detect drift over time.
-*   **The "Perfect Prompt" Fallacy:** Wasting weeks trying to engineer a prompt that works 100% of the time (instead of building error handling).
+## Does not define
+
+This module does not provide:
+
+- an exhaustive catalogue of every possible incident;
+- one universal severity model;
+- a guarantee that a single control eliminates a failure mode;
+- mandatory implementation technology;
+- post-mortems as normative requirements.
+
+Individual examples are illustrative. Mitigation normally requires a combination of boundaries, actuators, sensors, controller decisions, and operating procedures proportional to the system's consequences and context.
+
+## Key concepts
+
+- syntactic entropy;
+- semantic entropy;
+- probabilistic drift;
+- boundary breach;
+- open-loop deployment;
+- evidence failure;
+- controller or authority failure;
+- containment and recovery failure.
+
+## Relationships
+
+- [`00-doctrine/`](../00-doctrine/) provides the distinctions needed to explain why these failures occur.
+- [`01-patterns/`](../01-patterns/) contains reusable responses to recurring failure mechanisms.
+- [`02-ai-control-plane/`](../02-ai-control-plane/) provides the capabilities used to detect, interpret, and correct deviations.
+- [`03-reference-architectures/`](../03-reference-architectures/) demonstrates how failure handling may be composed in concrete systems.
+- [`SPECIFICATION.md`](../SPECIFICATION.md) defines the status and normative boundary of this taxonomy.
+
+## Initial taxonomy
+
+### 1. Syntactic entropy — the structure breaks
+
+The model output violates a technical contract required by the surrounding system.
+
+Illustrative examples:
+
+- malformed structured output;
+- incorrect field or value types;
+- repetition or non-terminating behavior;
+- context overflow or truncation;
+- outputs that cannot be parsed, validated, or safely executed.
+
+Typical controls include strict schemas, validation, bounded retries, deterministic parsing, execution limits, and explicit fallback paths.
+
+### 2. Semantic entropy — the meaning breaks
+
+The output is technically valid but functionally wrong, unsafe, misleading, or unsuitable for the operating context.
+
+Illustrative examples:
+
+- unsupported or false claims;
+- tone or policy drift;
+- unjustified refusal or over-restriction;
+- ignored instructions or negative constraints;
+- valid-looking actions that violate business intent.
+
+Typical controls include evaluations, golden scenarios, runtime outcome signals, policy checks, human review, escalation, and controller-authorized changes.
+
+### 3. Process and governance anti-patterns — the control system breaks
+
+The organization treats probabilistic behavior as if ordinary development and release practices were sufficient.
+
+Illustrative examples:
+
+- **Vibe-check release:** deployment based on a few favorable examples rather than risk-derived evidence;
+- **Hidden behavior configuration:** prompts, policies, or model settings embedded without ownership or traceability;
+- **Open-loop deployment:** operation without meaningful feedback or a mechanism for corrective action;
+- **Perfect-prompt fallacy:** attempting to eliminate uncertainty through prompting instead of engineering containment and recovery;
+- **Telemetry without authority:** collecting metrics without assigning who may intervene or change the system;
+- **Human-in-the-loop theatre:** nominal approval steps without adequate context, time, competence, or real decision power.
 
 ## Contribution
-This section is a library of "Battle Scars." We encourage submitting **Post-Mortems** of real-world failures to help the community build better containment strategies.
+
+Operational failure reports and post-mortems are valuable inputs to this module. Contributions should distinguish observed evidence from interpretation, identify operating context and consequences, and avoid presenting a single incident as a universal rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,15 @@ Project publications, talks, community discussions, and independent references a
 - Added a normalization report documenting provenance, transformations, quality checks, and unresolved publication metadata.
 - Added a canonical project roadmap in `ROADMAP.md`.
 - Added a project-history area separating the timeline, public talks, and independent references from release history and normative specification content.
+- Added `SPECIFICATION.md` as the canonical specification boundary and document-status index.
 
 ### Changed
 
 - Simplified the repository contribution and research workflow for maintainer-led development while preserving deliberate review for normative, high-impact, automated, and externally contributed changes.
 - Reframed research review artifacts as proportional tools rather than mandatory components of every research update.
-- Clarified repository navigation and the distinct responsibilities of `README.md`, `ROADMAP.md`, `CHANGELOG.md`, `content/research/`, and `content/history/`.
+- Redesigned the root README as a specification landing page with direct navigation to research, discussions, independent references, talks, and the changelog.
+- Normalized the entry-point structure and status declarations of the five primary specification modules.
+- Adopted **Thinking Systems** as the current UA system-category term. **Behavioral Software** and **Behavioral Applications** are retained only as explicitly identified historical terminology in archived sources and provenance records.
 
 ## [0.1.0] - 2025-12-09
 

--- a/README.md
+++ b/README.md
@@ -10,27 +10,55 @@ The project is designed primarily for small and medium-sized engineering organiz
 
 ## Start Here
 
-Choose the path that matches what you need:
-
+- **Read the specification boundary and status model:** [`SPECIFICATION.md`](SPECIFICATION.md)
 - **Understand the core concepts:** [`00-doctrine/`](00-doctrine/)
 - **Apply reusable engineering patterns:** [`01-patterns/`](01-patterns/)
 - **Design the control loop:** [`02-ai-control-plane/`](02-ai-control-plane/)
 - **Review concrete architectures:** [`03-reference-architectures/`](03-reference-architectures/)
 - **Study recurring failure modes:** [`04-failure-modes/`](04-failure-modes/)
-- **Trace the research behind the specification:** [`content/research/`](content/research/)
-- **Follow project history, talks, discussions, and external references:** [`content/history/`](content/history/)
-- **See what is being built next:** [`ROADMAP.md`](ROADMAP.md)
+- **Trace the research behind UA:** [`content/research/`](content/research/)
+- **See project direction:** [`ROADMAP.md`](ROADMAP.md)
 
 ## The Core Shift
 
 Traditional software is mostly built from deterministic components and predefined execution paths. LLM-backed and agentic systems introduce components whose behavior remains probabilistic at runtime.
 
-UA calls this broader class **Behavioral Software**:
+UA calls this broader class **Thinking Systems** (previously described in historical UA publications as **Behavioral Software** or **Behavioral Applications**):
 
 - **Linear Software** follows explicitly coded paths.
-- **Behavioral Software** pursues goals within constraints while selecting or generating parts of the path dynamically.
+- **Thinking Systems** delegate part of runtime interpretation, judgment, planning, or path selection to probabilistic models while retaining explicit deterministic boundaries and control.
+
+Agentic systems are a higher-autonomy subset of Thinking Systems, not a synonym for the whole category.
 
 The architectural problem is therefore not only model quality. It is how probabilistic judgment is connected to business rules, permissions, data, human authority, release processes, monitoring, and correction.
+
+## Core Model
+
+UA treats AI governance as an engineering control problem.
+
+> **Reliable AI = Actuators + Sensors + Controller**
+
+- **Actuators** shape and constrain behavior: prompts, schemas, policies, permissions, tools, model settings, and execution boundaries.
+- **Sensors** detect deviation: evaluations, golden scenarios, runtime signals, incidents, qualitative review, and drift monitoring.
+- **Controller** determines corrective action: release gates, ownership, escalation, rollback, retraining, prompt or policy changes, and human decision authority.
+
+This control loop surrounds a critical distinction:
+
+- **Deterministic Core** — business rules, invariants, authentication, data handling, auditability, and safety constraints.
+- **Model Judgment** — interpretation, synthesis, classification under ambiguity, open-ended generation, and uncertain tool choice.
+
+UA focuses on the boundary between these regions.
+
+```mermaid
+graph TD;
+    A[Deterministic Core / Business Logic] -->|Request + Constraints| B[Boundary Layer / AI Control Plane];
+    B -->|Bounded Invocation| C{Model Judgment / LLM};
+    C -->|Candidate Output| B;
+    B -->|Validate + Gate| D[Quality, Safety, and Policy Checks];
+    D -->|Pass| E[User / Downstream System];
+    D -->|Fail| F[Fallback / Retry / Escalation];
+    F --> B;
+```
 
 ## What UA Is — and Is Not
 
@@ -49,39 +77,9 @@ UA is not:
 - a compliance certification;
 - a claim that uncertainty can be removed from model behavior.
 
-## Core Model
+## Repository Structure
 
-UA treats AI governance as an engineering control problem.
-
-> **Reliable AI = Actuators + Sensors + Controller**
-
-- **Actuators** shape and constrain behavior: prompts, schemas, policies, permissions, tools, model settings, and execution boundaries.
-- **Sensors** detect deviation: evaluations, golden scenarios, runtime signals, incidents, qualitative review, and drift monitoring.
-- **Controller** determines corrective action: release gates, ownership, escalation, rollback, retraining, prompt or policy changes, and human decision authority.
-
-This control loop surrounds a critical distinction:
-
-- **Deterministic Core** — business rules, invariants, authentication, data handling, auditability, safety constraints.
-- **Model Judgment** — interpretation, synthesis, classification under ambiguity, open-ended generation, and uncertain tool choice.
-
-UA focuses on the boundary between these regions.
-
-## Conceptual Architecture
-
-```mermaid
-graph TD;
-    A[Deterministic Core / Business Logic] -->|Request + Constraints| B[Boundary Layer / AI Control Plane];
-    B -->|Bounded Invocation| C{Model Judgment / LLM};
-    C -->|Candidate Output| B;
-    B -->|Validate + Gate| D[Quality, Safety, and Policy Checks];
-    D -->|Pass| E[User / Downstream System];
-    D -->|Fail| F[Fallback / Retry / Escalation];
-    F --> B;
-```
-
-## Repository Map
-
-### Normative framework
+### Specification modules
 
 - [`00-doctrine/`](00-doctrine/) — core concepts, terminology, and boundary thinking.
 - [`01-patterns/`](01-patterns/) — reusable containment and interface patterns.
@@ -89,19 +87,29 @@ graph TD;
 - [`03-reference-architectures/`](03-reference-architectures/) — worked architectural applications.
 - [`04-failure-modes/`](04-failure-modes/) — recurring technical and socio-technical failure modes.
 
-### Supporting records
+The canonical boundary, status vocabulary, and conformance model are defined in [`SPECIFICATION.md`](SPECIFICATION.md).
 
-- [`content/research/`](content/research/) — publications, analysis, provenance, and research-to-framework traceability. Research remains non-normative until deliberately adopted.
-- [`content/history/`](content/history/) — project timeline, talks, public stress tests, and independent references.
-- [`ROADMAP.md`](ROADMAP.md) — canonical direction and future priorities.
-- [`CHANGELOG.md`](CHANGELOG.md) — repository and specification-artifact changes only.
+### Supporting material
+
+- [`content/research/`](content/research/) — research corpus, provenance, analysis, synthesis, and research-to-framework traceability.
+- [`content/history/`](content/history/) — project milestones, talks, discussions, and independent references.
+- [`ROADMAP.md`](ROADMAP.md) — current direction and future priorities.
+- [`CHANGELOG.md`](CHANGELOG.md) — changes to repository and specification artifacts.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution and review workflow.
 
-### Operational assets
+## Evidence and Project History
 
-- [`assets/`](assets/) — diagrams and visual references.
-- [`scripts/`](scripts/) — repository-maintenance automation.
-- [`templates/`](templates/) — reusable contribution and specification templates.
+UA keeps different kinds of evidence separate:
+
+- [**Research**](content/research/) explains where ideas and claims originated and how they evolved.
+- [**Public discussions and stress tests**](content/history/community-discussions.md) record critique, alternatives, unresolved questions, and external pressure on the concepts.
+- [**Independent references and recognition**](content/history/external-recognition.md) record how third parties cited, interpreted, recommended, or used the work.
+- [**Talks and presentations**](content/history/talks.md) record practitioner sessions and public presentations without treating invitations as technical validation.
+- The [**changelog**](CHANGELOG.md) records changes to repository and specification artifacts.
+
+This separation prevents visibility, attention, recommendations, advisory relationships, or invited talks from being mistaken for technical validation, certification, institutional endorsement, or formal adoption.
+
+The evidence policy and complete historical index are maintained in [`content/history/`](content/history/).
 
 ## Current Status
 
@@ -109,20 +117,7 @@ graph TD;
 
 The current priority is to consolidate the research corpus into a coherent framework spine, clarify normative boundaries, and derive a practical SMB-facing artifact for mapping risks, required controls, and control cost.
 
-Detailed status and sequencing are maintained in [`ROADMAP.md`](ROADMAP.md).
-
-## Evidence and Project History
-
-UA keeps different kinds of evidence separate:
-
-- research explains where ideas and claims originated;
-- public discussions record critique, alternatives, and stress tests;
-- independent references record how third parties interpreted or used the concepts;
-- the changelog records changes to repository artifacts.
-
-This prevents visibility, attention, recommendations, or invited talks from being mistaken for technical validation or formal adoption.
-
-See [`content/history/`](content/history/) for the evidence policy and historical records.
+See [`ROADMAP.md`](ROADMAP.md) for current sequencing.
 
 ## Community and Contributions
 
@@ -132,40 +127,23 @@ Useful contributions include operational failure reports, pattern proposals, cri
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-## Authors and Maintainers
+## Authors, Maintainers, and Advisors
 
-### Vitalii Oborskyi — Creator and Lead Architect
+**Vitalii Oborskyi — Creator and Lead Architect**  
+Operational framing, governance, delivery systems, adoption scaffolding, and system-level control. [LinkedIn](https://www.linkedin.com/in/vitaliioborskyi/) · [GitHub](https://github.com/oborskyivitalii)
 
-Focus: operational framing, governance, delivery systems, adoption scaffolding, and system-level control.
+**Sam “stunspot” Walker — Technical Co-Author**  
+AI–code boundary placement, containment patterns, prompt-as-medium realism, and real-world failure modes.
 
-- [LinkedIn](https://www.linkedin.com/in/vitaliioborskyi/)
-- [GitHub](https://github.com/oborskyivitalii)
+**Markus Kopko — Strategic Advisor on Governance and Alignment**  
+Project-management standards, organizational alignment, and operationalization of AI governance. [LinkedIn](https://www.linkedin.com/in/markuskleinpmp/)
 
-### Sam “stunspot” Walker — Technical Co-Author
+**Otman Basir, Ph.D. — Academic Advisor**  
+Professor of Intelligent Systems at the University of Waterloo and author of the Social Responsibility Stack. [LinkedIn](https://www.linkedin.com/in/otman-basir-ba1258178)
 
-Focus: AI–code boundary placement, containment patterns, prompt-as-medium realism, and real-world failure modes.
+Advisory relationships are part of the project's operating context. They do not imply institutional endorsement, certification, or formal adoption of UA. Supporting public evidence and precise claim boundaries are recorded in [`content/history/external-recognition.md`](content/history/external-recognition.md).
 
-Additional contributors and reviewers are credited as the work matures.
-
-## Advisors
-
-### Markus Kopko — Strategic Advisor on Governance and Alignment
-
-Focus: project-management standards, organizational alignment, and the operationalization of AI governance.
-
-- [LinkedIn](https://www.linkedin.com/in/markuskleinpmp/)
-
-### Otman Basir, Ph.D. — Academic Advisor
-
-Professor of Intelligent Systems at the University of Waterloo and author of the Social Responsibility Stack. His role supports the connection between control-theoretic research and practical engineering governance.
-
-- [LinkedIn](https://www.linkedin.com/in/otman-basir-ba1258178)
-
-Advisory relationships are listed because they are part of the project's operating context. They do not imply institutional endorsement, certification, or formal adoption of UA.
-
-See [`content/history/external-recognition.md`](content/history/external-recognition.md) for supporting public evidence and precise claim boundaries.
-
-## How to Cite
+## Citation
 
 ```bibtex
 @misc{oborskyi_walker2025uncertainty,
@@ -184,4 +162,4 @@ This repository uses a dual-license model:
 - documentation and specifications: CC BY 4.0;
 - code and reference implementations: Apache 2.0.
 
-See [`LICENSING.md`](LICENSING.md) for details.
+See [`LICENSING.md`](LICENSING.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,16 +39,20 @@ The objective is to consolidate the existing research into a coherent, bounded s
 - five historical publications normalized and archived under `content/research/publications/`;
 - provenance and normalization report added;
 - research-to-framework traceability scaffold created;
-- repository contribution and research workflow simplified for maintainer-led development.
+- repository contribution and research workflow simplified for maintainer-led development;
+- canonical specification boundary and document-status model established in `SPECIFICATION.md`;
+- root README redesigned as the project landing page with direct evidence navigation;
+- primary module entry points normalized around a shared structure;
+- **Thinking Systems** adopted as the current system-category term, with **Behavioral Software** and **Behavioral Applications** retained only as historical terminology.
 
 ### Active and next milestones
 
 - [ ] Complete a cross-publication research synthesis.
 - [ ] Identify stable concepts, later refinements, contradictions, and superseded claims.
-- [ ] Review terminology, including the relationship between Behavioral Software, Thinking Systems, and agentic systems.
+- [ ] Define the relationship between Thinking Systems and higher-autonomy agentic systems in the canonical glossary.
 - [ ] Produce a concise framework-spine proposal.
 - [ ] Clarify normative boundaries across Doctrine, Patterns, AI Control Plane, Operating Model, Reference Architectures, Failure Modes, and practical artifacts.
-- [ ] Improve repository navigation so readers can move from the overview to research and normative material without ambiguity.
+- [ ] Consolidate canonical definitions in a repository glossary.
 
 ## Phase 3 — Patterns and Failure Modes
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -8,7 +8,9 @@
 
 This document defines the normative boundary and document structure of Uncertainty Architecture (UA).
 
-UA is an open specification for designing and governing software systems whose runtime behavior depends partly on probabilistic models. It treats reliability as a system property produced by explicit boundaries, observable behavior, feedback, decision rights, and controlled change rather than by model quality alone.
+UA is an open specification for designing and governing **Thinking Systems**: software systems whose runtime behavior depends partly on probabilistic model judgment while consequential deterministic boundaries and control responsibilities remain explicit. Earlier UA publications used **Behavioral Software** and **Behavioral Applications** for this category.
+
+UA treats reliability as a system property produced by explicit boundaries, observable behavior, feedback, decision rights, and controlled change rather than by model quality alone.
 
 This file is the canonical entry point for the specification. It does not duplicate the detailed content of the modules it indexes.
 
@@ -129,6 +131,6 @@ Research findings, talks, articles, implementations, and external frameworks do 
 
 ## 9. Current maturity
 
-UA is in active development. The repository already contains a conceptual spine, patterns, a control-plane model, reference material, and failure-mode work, but these areas are not yet uniformly classified or complete.
+UA is in active development. The repository contains a conceptual spine, normalized module entry points, patterns, a control-plane model, reference material, and failure-mode work, but detailed normative content remains incomplete and may change.
 
-Until module-level status declarations are normalized, readers SHOULD treat existing specification modules as **draft normative**, except for reference architectures and clearly identified examples, which are **reference** or **informative**.
+Readers SHOULD follow the explicit status declared by each module or document. Reference architectures and clearly identified examples remain **reference** or **informative**, not mandatory implementation requirements.

--- a/content/history/talks.md
+++ b/content/history/talks.md
@@ -36,7 +36,7 @@ Vitalii Oborskyi joined an internal technical AI workshop for Corning Incorporat
 
 Topics included:
 
-- the transition from deterministic software paths to behavioral systems;
+- the transition from deterministic software paths to Thinking Systems (then described in the session as behavioral systems);
 - the use of control theory for socio-technical feedback loops;
 - separating deterministic constraints from model judgment;
 - risks that emerge at the level of teams, operating models, ownership, and escalation rather than only in source code;

--- a/content/research/framework-traceability.md
+++ b/content/research/framework-traceability.md
@@ -58,10 +58,10 @@ This section records cross-source issues that cannot be resolved inside simple e
 
 | Topic | Earlier formulation | Later formulation | Current status | Resolution path |
 |---|---|---|---|---|
+| Primary system category | Behavioral Software / Behavioral Applications | Thinking Systems | Active | Use Thinking Systems in current framework documents; preserve legacy wording in historical sources with an explanatory terminology note |
 
-Initial topics expected to require review include:
+Initial topics expected to require further review include:
 
-- Behavioral Software / Behavioral Applications versus a possible Thinking Systems taxonomy;
 - the relationship between Thinking Systems and agentic systems;
 - Model Control Plane versus Model Context Protocol acronym conflict;
 - AI Control Plane as platform, architectural layer, capability, or pattern vocabulary;

--- a/content/research/index.md
+++ b/content/research/index.md
@@ -124,13 +124,15 @@ The initial corpus includes:
 5. *Beyond Embeddings: Neuro-Symbolic Verification of Semantic Drift in LLMs*;
 6. the *Designing Non-Deterministic Systems* presentation as a research synthesis source.
 
-## Terminology under review
+## Terminology decision
 
-Historical publications use terms such as **Behavioral Software** and **Behavioral Applications**.
+Current UA terminology uses **Thinking Systems** for software that delegates part of runtime interpretation, judgment, planning, or decision-making to probabilistic models while retaining explicit deterministic boundaries and control responsibilities.
 
-The current research direction is considering **Thinking Systems** as a clearer user-facing category for software that delegates part of runtime interpretation, judgment, planning, or decision-making to probabilistic models. Agentic systems may be treated as a higher-autonomy subset rather than as a synonym.
+Historical publications used **Behavioral Software** and **Behavioral Applications**. Current framework documents may identify the migration on first use as **Thinking Systems** (previously described as **Behavioral Software** or **Behavioral Applications**), but should use **Thinking Systems** thereafter.
 
-This terminology is **not adopted by this research scaffolding**. It requires a separate terminology review after the relevant sources have been synthesized. Historical publications retain their original language.
+Agentic systems are treated as a higher-autonomy subset of Thinking Systems rather than as a synonym for the whole category.
+
+Historical publications and raw sources retain their original language for provenance. Repository editions should include a terminology note when the legacy category is material to the text.
 
 ## Licensing
 

--- a/content/research/publications/README.md
+++ b/content/research/publications/README.md
@@ -1,0 +1,31 @@
+# Historical Research Publications
+
+**Status:** Research archive
+
+This directory contains normalized repository editions of publications that contributed to the development of Uncertainty Architecture.
+
+The documents are preserved as historical research evidence. Their original arguments, category names, and publication titles are not automatically current specification language.
+
+## Terminology migration
+
+Current UA terminology uses **Thinking Systems** for software that delegates part of runtime interpretation, judgment, planning, or decision-making to probabilistic models while retaining explicit deterministic boundaries and control responsibilities.
+
+Some historical publications in this directory use **Behavioral Software**, **Behavioral Applications**, or the lowercase phrase **behavioral systems** for the same emerging category. Those terms are historical predecessors of **Thinking Systems** and should not be used as the current UA category in new framework documents.
+
+The archived wording is retained because silently replacing terminology inside historical publications would erase the evolution of the framework and make citations diverge from the originally published material. When discussing these sources in current work, use:
+
+> **Thinking Systems** (previously described as **Behavioral Software** or **Behavioral Applications**)
+
+After the migration has been identified once, use **Thinking Systems**.
+
+Generic uses of words such as *behavior*, *behavioral constraint*, or *behavioral evidence* are not category names and are not automatically deprecated.
+
+## Repository editions
+
+- [`architecting-uncertainty-a-modern-guide-to-llm-based-software.md`](architecting-uncertainty-a-modern-guide-to-llm-based-software.md)
+- [`arkhitektura-nevyznachenosti-suchasnyi-pidkhid-do-proiektuvannia-llm-zastosunkiv.md`](arkhitektura-nevyznachenosti-suchasnyi-pidkhid-do-proiektuvannia-llm-zastosunkiv.md)
+- [`uncertainty-architecture-a-modern-approach-to-designing-llm-applications.md`](uncertainty-architecture-a-modern-approach-to-designing-llm-applications.md)
+- [`uncertainty-architecture-why-ai-governance-is-actually-control-theory.md`](uncertainty-architecture-why-ai-governance-is-actually-control-theory.md)
+- [`beyond-embeddings-architecting-risk-and-logic-in-the-age-of-behavioral-software.md`](beyond-embeddings-architecting-risk-and-logic-in-the-age-of-behavioral-software.md)
+
+See the parent [Research Track index](../index.md) for the normative boundary and research-review model.

--- a/content/research/research-analysis-template.md
+++ b/content/research/research-analysis-template.md
@@ -69,7 +69,7 @@ For each claim:
 |---|---|---|---|
 | [Term] | [Meaning] | [Current meaning] | [Retain / narrow / rename / supersede / unresolved] |
 
-Explicitly review historical terms such as Behavioral Software, Behavioral Applications, Model Control Plane, AI Control Plane, actuators, constraints, sensors, controller, and specialized role names whenever they appear.
+Explicitly review legacy terms such as Behavioral Software and Behavioral Applications against the current **Thinking Systems** category whenever they appear. Also review Model Control Plane, AI Control Plane, actuators, constraints, sensors, controller, and specialized role names where relevant.
 
 ## Methodology impact
 


### PR DESCRIPTION
## What changed

This PR adopts **Thinking Systems** as the current UA system-category term across active framework and navigation documents.

It updates:

- the root `README.md`;
- `SPECIFICATION.md`;
- `ROADMAP.md`;
- the five primary module entry points;
- research index and traceability records;
- the research-analysis template;
- the talks record;
- `CHANGELOG.md`.

The first current-framework references explain the migration as:

> **Thinking Systems** (previously described as **Behavioral Software** or **Behavioral Applications**)

Subsequent current usage uses **Thinking Systems** only.

## Historical-source policy

Historical publications and raw source snapshots are not silently rewritten. Their original titles and wording are retained for provenance and citation integrity.

A new `content/research/publications/README.md` explains that:

- `Behavioral Software`, `Behavioral Applications`, and category-level `behavioral systems` are historical predecessors of **Thinking Systems**;
- new framework documents should use **Thinking Systems**;
- generic uses of words such as behavior, behavioral constraint, or behavioral evidence are not automatically deprecated;
- current discussion of an archived source should identify the migration on first use.

## Agentic systems

The active terminology now treats agentic systems as a higher-autonomy subset of Thinking Systems, not as a synonym for the entire category.

## Consolidation note

PR #10 and PR #11 were created as stacked PRs and were merged into their feature-branch bases rather than directly into `main`. Their approved README and module-entry-point changes therefore had not reached `main`.

This PR is based cleanly on current `main` and carries those changes forward together with the terminology migration. It does not modify historical publication bodies or raw research snapshots.

## Validation

- branch is 14 commits ahead and zero commits behind `main`;
- 14 files change;
- active framework documents use **Thinking Systems** as the category;
- remaining `Behavioral Software` / `Behavioral Applications` references in changed active documents are explicitly identified as historical terminology;
- historical titles and archived source wording remain unchanged by design.