### PR TITLE
docs: require changelog updates and source-entity classification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,31 +27,29 @@ canonical_for:
 
 This file defines how language models, coding agents, automated reviewers, and other AI-assisted contributors should work inside the Uncertainty Architecture (UA) repository.
 
-It is an operational protocol for repository work. It is not part of the normative UA specification and does not create a second source of doctrine, terminology, conformance, or architectural authority.
+It is operational guidance, not part of the normative UA specification. It must not override [`SPECIFICATION.md`](SPECIFICATION.md), explicit document status, a module boundary, or a canonical definition in [`00-doctrine/glossary.md`](00-doctrine/glossary.md).
 
 Use this file to determine:
 
-- which documents to read before making a change;
-- where a new contribution belongs;
-- which source has authority when documents appear to conflict;
-- how to preserve terminology, provenance, and historical accuracy;
-- how to finish a session without introducing conceptual or structural drift.
-
-This file must not be used to override [`SPECIFICATION.md`](SPECIFICATION.md), an explicit document status, the relevant module index, or a canonical definition in [`00-doctrine/glossary.md`](00-doctrine/glossary.md).
+- what to read before editing;
+- where a contribution belongs;
+- which source has authority;
+- how to preserve terminology, provenance, and history;
+- how to finish a session without conceptual, structural, or documentation drift.
 
 ## 2. Repository mission
 
-Uncertainty Architecture is an open doctrine and pattern language for building and operating software in which part of the system's behavior is delegated to non-deterministic model judgment while the surrounding system remains deterministic, inspectable, and governable.
+UA is an open doctrine and pattern language for building and operating software in which part of the system's behavior is delegated to non-deterministic Model Judgment while the surrounding system remains deterministic, inspectable, and governable.
 
-The repository exists to evolve an open engineering specification for Thinking Systems at the AI-code boundary.
+The repository exists to evolve an open engineering specification for **Thinking Systems** at the AI-code boundary.
 
 UA is:
 
 - a shared architectural language;
-- a doctrine for reasoning about deterministic boundaries and probabilistic judgment;
-- a pattern system for containment, evaluation, escalation, fallback, and correction;
+- a doctrine for deterministic boundaries and probabilistic judgment;
+- a pattern system for containment, evaluation, escalation, fallback, rollback, and correction;
 - a control-oriented approach to operating model-mediated software;
-- a tool-neutral specification intended to evolve through research and implementation evidence.
+- a tool-neutral specification that evolves through research and implementation evidence.
 
 UA is not:
 
@@ -60,9 +58,7 @@ UA is not:
 - a vendor-specific architecture;
 - a single evaluation method;
 - a compliance certification;
-- a claim that model uncertainty can be eliminated.
-
-Repository work should strengthen conceptual integrity, practical engineering usefulness, traceability, and long-term maintainability of the specification.
+- a claim that uncertainty can be eliminated.
 
 ## 3. Mental model for AI contributors
 
@@ -73,128 +69,121 @@ Prefer:
 - system boundaries over isolated components;
 - responsibilities over job titles;
 - invariants over implementation preferences;
-- reusable architectural distinctions over project-specific vocabulary;
-- evidence and explicit reasoning over confident generalization;
+- reusable distinctions over project-specific vocabulary;
+- evidence over confident generalization;
 - cross-references over duplicated definitions;
-- refinement of existing concepts over unnecessary expansion;
-- control-loop completeness over local technical sophistication.
+- refinement over unnecessary expansion;
+- complete control loops over locally impressive tools.
 
-Do not assume that a technically impressive implementation is architecturally sufficient. A prompt, evaluator, guardrail, agent, workflow engine, or telemetry system may implement one control capability without closing the system-level loop.
-
-When reviewing a proposed control structure, identify at least:
+When reviewing a proposed control structure, identify:
 
 1. where Model Judgment occurs;
 2. which deterministic boundaries and invariants constrain it;
-3. what evidence makes relevant behavior or outcomes observable;
+3. what evidence makes behavior and outcomes observable;
 4. who or what interprets that evidence;
 5. who or what has authority to change system behavior;
-6. which corrective actions are actually available;
+6. which corrective actions are available;
 7. how fallback, escalation, containment, rollback, or shutdown works;
-8. how the decision and its assumptions remain traceable.
+8. how assumptions and decisions remain traceable.
 
 ## 4. Authority and conflict resolution
 
-When repository documents appear to conflict, do not resolve the conflict by recency, popularity, file location, external visibility, or confidence of wording.
+When documents appear to conflict, do not resolve the conflict by recency, popularity, file location, external visibility, or confidence of wording.
 
-Use this order of interpretation:
+Use this order:
 
-1. [`SPECIFICATION.md`](SPECIFICATION.md) for specification scope, normative language, status vocabulary, conformance, and change control.
-2. The explicit status and normative language of the documents involved.
-3. The relevant module README for the purpose and boundary of that module.
-4. [`00-doctrine/glossary.md`](00-doctrine/glossary.md) for current canonical meanings of terms it defines.
-5. Accepted doctrine and other current specification content for the architectural meaning of concepts.
-6. [`DOCUMENT-METADATA.md`](DOCUMENT-METADATA.md) for metadata and controlled tagging conventions.
-7. Research, history, talks, external references, and examples for evidence, provenance, interpretation, and evolution, not automatic requirements.
+1. [`SPECIFICATION.md`](SPECIFICATION.md) for specification scope, status vocabulary, conformance, and change control.
+2. Explicit document status and normative language.
+3. The relevant module README for module purpose and boundaries.
+4. [`00-doctrine/glossary.md`](00-doctrine/glossary.md) for current meanings of terms it defines.
+5. Current doctrine and other specification content for architectural meaning.
+6. [`DOCUMENT-METADATA.md`](DOCUMENT-METADATA.md) for metadata and tags.
+7. Research, history, talks, external references, and examples for evidence and context, not automatic requirements.
 8. This file for agent behavior and repository workflow only.
 
 Additional rules:
 
-- Explicit document status takes precedence over directory name.
-- `Normative` content takes precedence over conflicting `draft-normative`, `informative`, `reference`, `research`, or `historical` material.
-- `Draft normative` content must not be presented as stable or accepted merely because it is newer.
-- Maturity fields such as `active`, `stable`, or `superseded` do not replace status.
-- A recent commit, article, citation, discussion, talk, implementation, benchmark, or external framework does not become UA doctrine by implication.
-- When two current normative or draft-normative sources genuinely conflict, report the contradiction instead of silently choosing one.
+- Explicit status takes precedence over directory name.
+- `Normative` content takes precedence over conflicting lower-status material.
+- `Draft normative` content must not be presented as stable.
+- Maturity does not replace status.
+- Research, talks, implementations, citations, or benchmarks do not become doctrine by implication.
+- Report genuine contradictions instead of silently choosing one side.
 
 ## 5. Repository invariants
 
-The following invariants protect the conceptual structure of the repository:
-
 1. Every canonical concept should have one authoritative definition.
-2. The glossary is the canonical terminology source for terms it currently defines.
+2. The glossary is the terminology source for terms it defines.
 3. Doctrine defines foundational distinctions; lower-level modules must not silently redefine them.
-4. Patterns describe reusable responses to recurring problems; they do not create local doctrine.
-5. AI Control Plane documents define control capabilities and their relationships; they do not imply one mandatory product topology.
+4. Patterns describe reusable responses; they do not create local doctrine.
+5. AI Control Plane documents define capabilities, not one mandatory product topology.
 6. Reference architectures compose concepts and patterns; they do not become mandatory by example.
-7. Failure modes describe reusable mechanisms of loss of control; they are not collections of unrelated product bugs.
-8. Research provides evidence, critique, provenance, and framework candidates; it does not become specification automatically.
-9. Historical material preserves what was said and when; it must not be rewritten to appear consistent with current doctrine.
-10. Raw source snapshots remain source evidence; they must not be normalized in place.
-11. One material type should have one canonical repository namespace.
+7. Failure modes describe reusable mechanisms of loss of control, not unrelated product defects.
+8. Research provides evidence and framework candidates; it is not automatically specification.
+9. Historical material preserves what was said and when.
+10. Raw snapshots remain source evidence and must not be normalized in place.
+11. One material type should have one canonical namespace.
 12. Navigation and publishing infrastructure must not become a second specification.
 13. Metadata, tags, recency, and search ranking do not create authority.
-14. Repository growth should occur by coherent refinement, not by fragmenting one concept across many partially overlapping files.
+14. Repository growth should occur through coherent refinement, not fragmentation.
+15. Every material repository change must remain visible in [`CHANGELOG.md`](CHANGELOG.md).
 
 ## 6. Canonical repository map and placement rules
 
 ### 6.1 Public entry points
 
-- [`README.md`](README.md) — public landing page and primary reader navigation. It presents the current project identity and points to canonical sources.
-- [`SPECIFICATION.md`](SPECIFICATION.md) — canonical specification boundary, status model, conformance entry point, and change-control rules.
-- [`ROADMAP.md`](ROADMAP.md) — current development sequence and planned artifacts.
-- [`CHANGELOG.md`](CHANGELOG.md) — repository-level record of material changes.
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution workflow, review expectations, and maintainer authority.
-- [`DOCUMENT-METADATA.md`](DOCUMENT-METADATA.md) — controlled frontmatter fields and hierarchical tag conventions.
-- [`AGENTS.md`](AGENTS.md) — this operational protocol for AI-assisted contributors.
+- [`README.md`](README.md) — public landing page and reader navigation.
+- [`SPECIFICATION.md`](SPECIFICATION.md) — specification boundary, status model, conformance, and change control.
+- [`ROADMAP.md`](ROADMAP.md) — development sequence and planned artifacts.
+- [`CHANGELOG.md`](CHANGELOG.md) — canonical record of notable repository and specification-artifact changes.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution and review workflow.
+- [`DOCUMENT-METADATA.md`](DOCUMENT-METADATA.md) — metadata and controlled tags.
+- [`AGENTS.md`](AGENTS.md) — this operational protocol.
 
 ### 6.2 `00-doctrine/`
 
-Purpose: foundational concepts, distinctions, boundaries, and canonical vocabulary on which the rest of UA depends.
+Purpose: foundational concepts, distinctions, boundaries, and canonical vocabulary.
 
-Place material here when it defines or materially refines how UA understands:
+Place material here when it defines or materially refines:
 
 - Thinking Systems;
 - Deterministic Core;
 - Model Judgment;
-- the Uncertainty Boundary;
+- Uncertainty Boundary;
 - invariants and responsibility boundaries;
 - control-oriented first principles;
-- core terminology.
+- core terminology and conceptual definitions such as Requirement, Bug, or Human Authority.
 
 Do not place here:
 
-- one-off implementation guidance;
-- vendor-specific recipes;
-- isolated project examples;
+- vendor recipes;
+- isolated implementation examples;
 - raw research notes;
 - historical records;
-- patterns that merely apply existing doctrine.
+- patterns that only apply existing doctrine.
 
-Any doctrine change must be checked for impact on the glossary, patterns, AI Control Plane, reference architectures, failure modes, module indexes, and changelog.
+A doctrine change must be checked against the glossary, patterns, AI Control Plane, reference architectures, failure modes, module indexes, and changelog.
 
 ### 6.3 `01-patterns/`
 
 Purpose: reusable technical and socio-technical responses to recurring control problems.
 
-A pattern should normally make visible:
+A pattern should make visible:
 
 - context;
 - problem;
 - forces and trade-offs;
 - proposed structure or control response;
-- consequences;
-- limitations;
-- relationship to doctrine and known failure modes.
+- consequences and limitations;
+- relationship to doctrine and failure modes.
 
-Do not promote a one-off implementation into a pattern unless the underlying problem and response plausibly generalize.
-
-Patterns must use existing doctrine and glossary terminology. If a pattern appears to require a new foundational concept, resolve that concept in doctrine first.
+Do not promote a one-off implementation into a pattern without a reusable problem and response.
 
 ### 6.4 `02-ai-control-plane/`
 
 Purpose: capabilities required to constrain, observe, evaluate, and correct model-mediated behavior.
 
-Relevant material may address:
+Relevant material includes:
 
 - actuators;
 - sensors and evidence;
@@ -202,420 +191,365 @@ Relevant material may address:
 - constraints and policy enforcement;
 - release and runtime gates;
 - escalation and Human Authority;
-- containment, fallback, rollback, or shutdown;
+- containment, fallback, rollback, and shutdown;
 - control latency, traceability, and corrective-action paths;
 - operating controls distributed across software and human processes.
 
-The AI Control Plane is an architectural capability model. Do not assume it must be one centralized service, product, platform, or team.
-
-When adding a control mechanism, state what behavior it can actually change and which authority can invoke it. Telemetry without a decision path is observation, not control.
+Telemetry without decision authority and corrective action is observation, not control.
 
 ### 6.5 `03-reference-architectures/`
 
 Purpose: concrete, non-prescriptive compositions showing how UA concepts and patterns may be applied.
 
-Reference architectures may combine doctrine, patterns, control capabilities, technologies, and operating roles into a worked design.
+Reference architectures may combine:
 
-They must:
+- doctrine;
+- patterns;
+- control capabilities;
+- technical artifacts;
+- technologies;
+- roles, responsibilities, and processes.
 
-- identify which parts are required by current specification content and which are illustrative;
-- avoid presenting one topology, vendor, model, or organizational structure as universal;
-- link to the doctrine and patterns they apply;
-- make assumptions, risk context, and unresolved limitations visible.
-
-A concept discovered through a reference architecture does not become canonical until it is reconciled with the owning module and glossary.
+They must separate specification requirements from illustrative choices and must not introduce local doctrine.
 
 ### 6.6 `04-failure-modes/`
 
 Purpose: recurring mechanisms by which Thinking Systems lose structural, semantic, operational, economic, or organizational control.
 
-A failure mode should normally describe:
+A failure mode should describe:
 
 - triggering conditions;
 - mechanism of failure;
 - observable signals;
 - consequences;
 - affected boundaries or control capabilities;
-- containment, mitigation, or recovery options;
-- unresolved uncertainty where applicable.
+- containment, mitigation, or recovery options.
 
-Do not describe an isolated product defect as a UA failure mode unless it exposes a reusable system mechanism.
+An isolated undesirable output is not automatically a reusable failure mode.
 
 ### 6.7 `content/research/`
 
 Purpose: research publications, notes, analysis, synthesis, critique, provenance, and research-to-framework traceability.
 
-Research may inform the specification, but research content is not automatically normative.
-
-When working with research:
-
-- distinguish source preservation from interpretation;
-- preserve attribution and publication provenance;
-- separate evidence from framework conclusions;
-- record contradictory evidence and limitations;
-- use explicit framework decisions to move ideas into normative modules.
-
-Start with [`content/research/index.md`](content/research/index.md) and use [`content/research/framework-traceability.md`](content/research/framework-traceability.md) for decision-oriented mapping where relevant.
+Research informs explicit framework decisions. It does not update doctrine by implication.
 
 ### 6.8 `content/history/`
 
-Purpose: project chronology, public discussions, talks, external references, recognition, and superseded records retained for traceability.
+Purpose: project chronology, public discussions, talks, external references, recognition, and superseded records.
 
-Historical material must remain historically accurate.
-
-Do not:
-
-- silently modernize terminology in historical titles or source bodies;
-- turn invitations, views, reactions, reposts, recommendations, or advisory relationships into technical validation;
-- describe an implementation, citation, or discussion as adoption or certification without evidence supporting that exact claim.
-
-Use clarification, annotation, or supersession notes instead of rewriting the past.
+Preserve historical wording and distinguish citation, recommendation, implementation, adoption, certification, and endorsement.
 
 ### 6.9 `content/raw/`
 
-Purpose: preserved source snapshots used for normalized research editions and provenance.
+Purpose: preserved source snapshots.
 
-Raw material is source evidence, not current doctrine.
+Do not paraphrase, modernize, normalize, or overwrite them in place.
 
-Do not paraphrase, normalize, modernize, or overwrite raw snapshots in place.
+### 6.10 Publishing and infrastructure
 
-### 6.10 Publishing and repository infrastructure
-
-- `content/index.md` is a publishing portal for the Quartz site, not a second specification entry point.
-- `quartz/`, `quartz.config.ts`, `quartz.layout.ts`, Node package files, and `vercel.json` are publishing infrastructure.
+- `content/index.md` is a publishing portal, not a second specification entry point.
+- `quartz/`, Node configuration, and `vercel.json` are publishing infrastructure.
 - `assets/` contains diagrams and visual references.
 
-Infrastructure behavior is not a UA requirement unless a specification document explicitly makes it one.
-
-Keep publishing-only changes separate from methodology changes when practical.
+Infrastructure behavior is not a UA requirement unless a specification document says so.
 
 ## 7. Canonical terminology
 
-The canonical vocabulary of UA is maintained in [`00-doctrine/glossary.md`](00-doctrine/glossary.md).
+The canonical vocabulary is maintained in [`00-doctrine/glossary.md`](00-doctrine/glossary.md).
 
-Before introducing, redefining, replacing, deprecating, or materially narrowing a UA-specific term:
+Before introducing, redefining, replacing, deprecating, or narrowing a UA term:
 
 1. read the glossary;
-2. search the repository for existing uses and near-synonyms;
-3. identify which module owns the underlying concept;
+2. search for existing uses and near-synonyms;
+3. identify the owning module;
 4. determine whether the distinction is necessary and stable;
-5. update the glossary in the same change when the canonical meaning changes.
+5. update the glossary in the same change when canonical meaning changes.
 
 Do not:
 
-- create a second glossary inside this file or another document;
-- define a canonical term locally inside a pattern or reference architecture;
-- invent a synonym merely to improve style;
-- add ordinary software-engineering vocabulary, vendor terminology, temporary labels, section headings, or one-off phrases to the glossary;
-- treat a memorable phrase as a canonical concept without a durable architectural distinction.
-
-A new glossary term should normally represent a concept that is necessary to understand or apply UA across more than one isolated document.
+- create a second glossary;
+- define canonical terms locally inside patterns or reference architectures;
+- invent synonyms for style;
+- add vendor vocabulary, temporary labels, section headings, or one-off phrases;
+- treat memorable phrases as canonical without a durable architectural distinction.
 
 ### 7.1 Terminology migration
 
-Use **Thinking Systems** as the current UA category for software systems whose runtime behavior depends partly on probabilistic model judgment while consequential deterministic boundaries, invariants, decision rights, and corrective mechanisms remain explicit.
+Use **Thinking Systems** in current framework material.
 
-Earlier UA publications used **Behavioral Software** and **Behavioral Applications**.
+Preserve **Behavioral Software** and **Behavioral Applications** in historical titles, quotations, preserved source bodies, raw snapshots, and provenance records.
 
-Rules:
-
-- Use `Thinking Systems` in new doctrine, patterns, AI Control Plane documents, reference architectures, failure modes, specification text, and current repository guidance.
-- Preserve `Behavioral Software` and `Behavioral Applications` in historical titles, quotations, preserved publication bodies, raw snapshots, and provenance records.
-- Do not silently rewrite historical material solely to modernize terminology.
-- When current documentation needs to connect old and new language, the first relevant reference may use:
+When current documentation first connects old and new language, it may use:
 
 > **Thinking Systems** (previously described as **Behavioral Software** or **Behavioral Applications**)
-
-Subsequent current discussion should use **Thinking Systems**.
 
 Agentic systems are a higher-autonomy subset of Thinking Systems, not a synonym for the whole category.
 
 ## 8. Editing rules
 
-### 8.1 Preserve ownership of concepts
+### 8.1 Preserve concept ownership
 
-- One concept should have one canonical definition and one owning module.
-- Prefer repository-relative links to duplicated explanations.
-- If an existing document owns the concept, refine or cross-reference it instead of creating a competing source.
-- Do not solve inconsistency by adding another document that restates both sides.
+- One concept, one canonical definition, one owning module.
+- Prefer links over duplicated explanations.
+- Refine the owning document instead of creating a competing source.
+- Do not reconcile inconsistency by adding another overlapping document.
 
-### 8.2 Separate normative content from evidence and examples
+### 8.2 Separate specification from evidence and examples
 
 - Research is evidence and analysis; doctrine is explicit synthesis.
-- A reference architecture demonstrates one composition; it does not establish a mandatory topology.
-- An example threshold is not a universal requirement.
-- A role name is not automatically a required job title.
-- A talk, article, benchmark, external citation, or implementation does not update the specification by implication.
+- Reference architectures demonstrate compositions; they do not establish mandatory topology.
+- Example thresholds are not universal requirements.
+- Role names are not automatically mandatory job titles.
+- Talks, articles, benchmarks, citations, and implementations do not update the specification by implication.
 
-### 8.3 Avoid false precision
+### 8.3 Classify socio-technical framework content explicitly
 
-Do not introduce universal numerical thresholds for quality, hallucination, drift, latency, cost, autonomy, confidence, Golden Scenario count, or review frequency without an explicit context- and risk-derived basis.
+When extracting material from talks, research, examples, or source publications, classify each candidate before placing it in the specification.
 
-When numbers are illustrative, label them as examples and state the conditions under which they may differ.
+Use these classes:
 
-### 8.4 Preserve uncertainty and disagreement
+- **Concept or definition** — a foundational distinction or canonical meaning; normally belongs in `00-doctrine/` and may require a glossary entry.
+- **Artifact** — a maintained object used to express intent, evidence, policy, state, or control, such as a Prompt Registry, Golden Scenario set, release manifest, risk map, escalation matrix, or decision record.
+- **Role or responsibility bundle** — decision rights, ownership, competence, and authority required to operate part of the control loop. Prefer responsibilities over mandatory job titles.
+- **Process or ritual** — a repeatable sequence through which evidence is reviewed and corrective action is authorized, such as drift review, release review, incident learning, or escalation.
+- **Technical reference artifact** — an illustrative schema, interface, manifest, data model, evaluator contract, repository layout, or implementation example.
+- **Pattern** — a reusable arrangement of artifacts, responsibilities, processes, and technical mechanisms that addresses a recurring control problem.
+- **Failure mode** — a reusable mechanism by which control is lost or becomes ineffective.
+- **Reference architecture** — a context-specific composition of several of the above.
 
-Do not convert unresolved research questions into settled doctrine.
+Do not create a new top-level repository namespace for these classes merely because the classification exists. Place each item in the module that owns its architectural meaning, and use indexes or cross-references to expose the complete socio-technical stack.
+
+### 8.4 Avoid false precision
+
+Do not introduce universal numerical thresholds for quality, hallucination, drift, latency, cost, autonomy, confidence, Golden Scenario count, or review frequency without a context- and risk-derived basis.
+
+### 8.5 Preserve uncertainty
 
 When evidence conflicts or a concept remains incomplete:
 
 - state the uncertainty;
 - preserve relevant alternatives;
-- identify the decision that remains open;
-- avoid language stronger than the available evidence supports.
+- identify the unresolved decision;
+- avoid language stronger than the evidence supports.
 
-### 8.5 Keep internal links and metadata coherent
+### 8.6 Keep links, metadata, and change records coherent
 
-- Use repository-relative links for internal files.
-- Link to the canonical index of a directory rather than copying its full document list into many places.
-- Do not link to nonexistent planned files; planned artifacts belong in `ROADMAP.md` until created.
-- Follow [`DOCUMENT-METADATA.md`](DOCUMENT-METADATA.md).
-- Do not infer authority from tags alone.
-- When moving or superseding content, preserve provenance and update inbound navigation.
+- Use repository-relative links.
+- Link to canonical module indexes rather than duplicating document lists.
+- Planned artifacts belong in `ROADMAP.md` until created.
+- Follow `DOCUMENT-METADATA.md`.
+- Preserve provenance when moving or superseding content.
+- Update `CHANGELOG.md` in the same branch and pull request for every notable repository or specification-artifact change.
+- Do not postpone a changelog entry to a later cleanup session.
 
 ## 9. Task-specific reading paths
 
 ### 9.1 Understanding UA
 
-1. Read [`README.md`](README.md).
-2. Read [`SPECIFICATION.md`](SPECIFICATION.md).
-3. Read [`00-doctrine/README.md`](00-doctrine/README.md).
-4. Read [`00-doctrine/glossary.md`](00-doctrine/glossary.md).
-5. Read the module relevant to the question.
-6. Use research and history when provenance, evidence, critique, or evolution matters.
+Read `README.md`, `SPECIFICATION.md`, `00-doctrine/README.md`, the complete glossary, and then the relevant module.
 
 ### 9.2 Editing doctrine or terminology
 
 1. Read `SPECIFICATION.md`.
-2. Read the relevant doctrine documents and module index.
+2. Read relevant doctrine and its module index.
 3. Read the complete glossary.
-4. Search the repository for all uses and near-synonyms of affected terms.
-5. Identify downstream dependencies in patterns, AI Control Plane, reference architectures, and failure modes.
-6. Update the glossary, indexes, links, and changelog when material.
+4. Search all uses and near-synonyms.
+5. Identify downstream impact.
+6. Update glossary, indexes, links, and changelog in the same change.
 7. State compatibility, supersession, and unresolved uncertainty.
 
 ### 9.3 Proposing or changing a pattern
 
-1. Read the doctrine and glossary terms the pattern relies on.
-2. Search `01-patterns/` for overlapping patterns.
-3. Review relevant failure modes.
-4. Identify which control-loop elements the pattern provides and which remain external.
-5. Distinguish reusable structure from implementation examples.
-6. Check whether the proposal actually requires a doctrine change first.
+Read relevant doctrine, glossary terms, overlapping patterns, and failure modes. Identify which control-loop capabilities the pattern provides and which remain external.
 
 ### 9.4 Editing the AI Control Plane
 
-1. Read the relevant doctrine and glossary entries.
-2. Identify actuator, sensor, controller, authority, evidence, and feedback path.
-3. State what behavior can be changed, contained, or stopped.
-4. Review reference architectures for downstream effects.
-5. Review failure modes that the control capability is intended to address.
-6. Check whether the change affects conformance reasoning in `SPECIFICATION.md`.
+Identify actuator, sensor, controller, authority, evidence, feedback path, and the behavior that can actually be changed, contained, or stopped.
 
 ### 9.5 Editing a reference architecture
 
-1. Read the relevant doctrine, patterns, and AI Control Plane documents.
-2. State context, assumptions, risk, autonomy, reversibility, and operating constraints.
-3. Separate required specification content from illustrative design choices.
-4. Avoid vendor lock-in unless vendor specificity is the point of the reference.
-5. Check that no local terminology or doctrine is being introduced implicitly.
+Read relevant doctrine, patterns, and Control Plane documents. State context, assumptions, risk, autonomy, reversibility, and operating constraints. Separate required content from illustrative design choices.
 
 ### 9.6 Editing a failure mode
 
-1. Identify the reusable mechanism, not only the observed symptom.
-2. Link the failure to affected boundaries, evidence, authority, or corrective mechanisms.
-3. Review existing failure modes for overlap.
-4. Distinguish deterministic defects, expected distribution tails, missing controls, inadequate sensors, controller failures, and invalid assumptions.
-5. State mitigations without pretending they guarantee elimination of the failure.
+Identify the reusable mechanism, not only the symptom. Distinguish deterministic defects, expected distribution tails, missing controls, inadequate sensors, controller failures, and invalid assumptions.
 
-### 9.7 Working with research
+### 9.7 Working with research or source extraction
 
-1. Start with `content/research/index.md`.
-2. Distinguish source, normalized edition, analysis, synthesis, and framework candidate.
-3. Preserve attribution and source meaning.
-4. Record evidence quality, scope, limitations, and contradictions.
-5. Use `content/research/framework-traceability.md` when mapping findings into repository decisions.
-6. Do not promote a claim into doctrine without an explicit normative change.
+Start with `content/research/index.md`. Distinguish source, normalized edition, analysis, synthesis, and framework candidate. Preserve evidence quality, scope, limitations, and contradictions.
 
-### 9.8 Working with history or external recognition
+For each extracted entity:
 
-1. Start with `content/history/README.md`.
-2. Distinguish publication, discussion, citation, recommendation, advisory relationship, invited talk, implementation, adoption, certification, and endorsement.
-3. Use evidence that supports the exact claim being recorded.
-4. Preserve criticism and alternative interpretations where material.
-5. Keep current terminology explanations outside preserved historical source bodies.
+1. state the source and original claim;
+2. classify it as concept, artifact, role/responsibility, process, technical reference artifact, pattern, failure mode, or reference architecture;
+3. identify the owning module;
+4. decide whether it is normative, draft normative, informative, reference, research, or historical;
+5. check glossary impact;
+6. identify dependencies and cross-references;
+7. update the changelog when the repository changes.
 
-### 9.9 Working with the publishing site
+### 9.8 Working with history
 
-1. Treat `content/index.md` as a publishing portal, not the canonical repository landing page.
-2. Do not move specification authority into Quartz configuration or generated navigation.
-3. Do not alter methodology merely to simplify site structure.
-4. Keep publishing changes separate from specification changes when practical.
+Start with `content/history/README.md`. Preserve source meaning and distinguish visibility from validation, adoption, certification, or endorsement.
 
 ## 10. Contribution workflow for AI-assisted changes
 
-For repository-changing work, follow this sequence:
+For repository-changing work:
 
-1. **Understand the request** — restate the architectural purpose and identify whether the change is normative, informative, reference, research, historical, or infrastructure.
-2. **Locate ownership** — identify the module and existing document that owns the concept.
-3. **Read dependencies** — follow the relevant task-specific reading path.
-4. **Search before creating** — check for existing terms, patterns, documents, and overlapping claims.
-5. **Assess authority** — verify status, maturity, module boundaries, and normative language.
-6. **Make the smallest coherent change** — prefer one reviewable architectural decision over broad unrelated cleanup.
-7. **Cross-reference** — link related doctrine, patterns, control capabilities, evidence, failure modes, and history where useful.
-8. **Check terminology** — compare all UA-specific wording with the glossary.
-9. **Check repository integrity** — verify metadata, navigation, provenance, and status boundaries.
-10. **Report uncertainty** — disclose contradictions, assumptions, evidence gaps, and decisions that remain unresolved.
-11. **Finish the session protocol** — complete the checklist in the next section before declaring the work done.
+1. **Understand** — identify the architectural purpose and document class.
+2. **Locate ownership** — identify the module and existing owning document.
+3. **Read dependencies** — follow the relevant reading path.
+4. **Search before creating** — check terms, patterns, documents, and overlapping claims.
+5. **Classify the entity** — concept, artifact, responsibility, process, technical reference artifact, pattern, failure mode, or reference architecture.
+6. **Assess authority** — verify status, maturity, module boundaries, and normative language.
+7. **Make the smallest coherent change** — prefer one reviewable decision.
+8. **Cross-reference** — connect doctrine, patterns, control capabilities, evidence, failure modes, and history.
+9. **Check terminology** — compare UA-specific wording with the glossary.
+10. **Update the changelog** — record every notable repository or specification-artifact change under `[Unreleased]` in the same branch and pull request.
+11. **Check repository integrity** — verify metadata, navigation, provenance, and status boundaries.
+12. **Report uncertainty** — disclose contradictions, assumptions, evidence gaps, and unresolved decisions.
+13. **Finish the session protocol** — complete the checks below.
 
-Substantial framework changes should be made on a branch and reviewed through a pull request under [`CONTRIBUTING.md`](CONTRIBUTING.md).
+Substantial framework changes should use a branch and pull request under [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## 11. End-of-session repository integrity protocol
 
-Before completing any session that changes repository content, perform all of the following checks.
+Before completing any session that changes repository content, perform all checks.
 
 ### 11.1 Placement review
 
-- Is each changed file in the correct canonical module or supporting namespace?
+- Is each file in the correct module or namespace?
 - Does the change have one clear architectural purpose?
-- Could an existing canonical document have been refined instead of adding a new file?
-- Was a new top-level namespace introduced without a repository-level decision?
+- Could an existing canonical document have been refined?
+- Was a new namespace introduced without a repository decision?
 
 ### 11.2 Authority and status review
 
-- Does the declared status match the actual language and role of the document?
-- Is draft material clearly represented as draft?
-- Did any informative, reference, research, historical, or infrastructure material accidentally create a normative claim?
+- Does status match the document's actual role and language?
+- Is draft material clearly marked?
+- Did lower-status material accidentally create a normative claim?
 - Does the change conflict with `SPECIFICATION.md` or a module boundary?
 
 ### 11.3 Terminology and glossary review
 
-Review [`00-doctrine/glossary.md`](00-doctrine/glossary.md) before finishing.
+Review the glossary before finishing.
 
-Check whether the session:
+Update it in the same change when the session:
 
-- introduced a new UA-specific concept;
-- changed the meaning, scope, or ownership of an existing term;
-- deprecated, replaced, or renamed a term;
-- created an alias or historical terminology relationship;
-- used a term inconsistently with the glossary;
-- exposed a missing distinction necessary to understand or apply the specification.
+- introduces a canonical UA concept;
+- changes a term's meaning, scope, or ownership;
+- deprecates, replaces, or renames a term;
+- creates an alias or historical relationship;
+- exposes a missing distinction necessary to apply the specification.
 
-If any condition applies, update the glossary in the same change and review downstream uses.
+Do not update the glossary merely because a phrase is new or memorable.
 
-Do not update the glossary merely because a phrase is new, memorable, convenient, vendor-specific, temporary, or used in only one isolated passage.
-
-If no glossary change is required, report:
+When unchanged, report:
 
 > Glossary reviewed — no canonical terminology change required.
 
-### 11.4 Cross-reference and navigation review
+### 11.4 Changelog review
 
-- Do related doctrine, patterns, AI Control Plane documents, reference architectures, and failure modes need links or updates?
-- Do module indexes need to include or supersede the changed artifact?
-- Do all internal links resolve to existing paths?
-- Were inbound links preserved after moving content?
-- Did the change create a duplicate canonical route?
+Review [`CHANGELOG.md`](CHANGELOG.md) before finishing.
 
-### 11.5 Provenance and historical review
+- Every notable repository or specification-artifact change must be recorded under `[Unreleased]` in the same branch and pull request.
+- Use `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security` as appropriate.
+- Describe the repository-level effect, not a low-level file-edit narrative.
+- Do not duplicate talks, publications, community discussions, or external recognition that belong in `content/history/`.
+- Do not postpone the entry to a later session.
 
-- Were quotations, titles, source bodies, dates, and attribution preserved?
-- Was historical language left intact where required?
-- Were visibility, recognition, invitations, or advisory relationships kept separate from validation, adoption, certification, or endorsement?
-- Were research conclusions kept separate from source evidence?
+When no changelog entry is appropriate because the change is purely mechanical or non-notable, explicitly report:
 
-### 11.6 Change-control review
+> Changelog reviewed — no notable repository or specification-artifact change required.
 
-- Is the change scoped to one coherent architectural decision?
+### 11.5 Cross-reference and navigation review
+
+- Do related modules need links or updates?
+- Do module indexes need to include or supersede the artifact?
+- Do internal links resolve?
+- Was provenance preserved after moving content?
+- Was a duplicate canonical route introduced?
+
+### 11.6 Provenance and historical review
+
+- Were titles, quotations, dates, attribution, and source bodies preserved?
+- Were historical terms left intact where required?
+- Were research conclusions separated from source evidence?
+- Were recognition and visibility kept separate from validation and adoption?
+
+### 11.7 Change-control review
+
+- Is the change one coherent architectural decision?
 - Are compatibility, supersession, and unresolved uncertainty explicit?
-- Does `CHANGELOG.md` need an entry because the change is material?
-- Does `ROADMAP.md` need an update because sequencing or planned scope changed?
-- Are the files changed and the rationale summarized clearly for reviewers?
+- Was `CHANGELOG.md` updated when the change was notable?
+- Does `ROADMAP.md` need an update because sequence or scope changed?
+- Are changed files and rationale summarized clearly?
 
 ## 12. Quality checklist
 
-Before proposing or approving a repository change, verify:
-
-- [ ] The target document has the correct status and maturity.
-- [ ] The change belongs in the selected module.
-- [ ] Current terminology is used outside historical material.
-- [ ] The glossary was reviewed and updated when required.
-- [ ] No existing canonical concept was redefined locally.
-- [ ] Examples are not written as universal requirements.
-- [ ] Responsibilities are not confused with mandatory job titles.
-- [ ] Research, history, and reference material remain outside the normative boundary unless explicitly promoted.
-- [ ] Controls include a real path to affect behavior, not telemetry alone.
-- [ ] The change does not imply that one tool or metric closes a system-level control loop.
-- [ ] Metadata fields and tags agree with the content.
-- [ ] Internal links resolve to existing files.
-- [ ] No duplicate canonical entry point or namespace was introduced.
+- [ ] Correct status and maturity.
+- [ ] Correct module and placement.
+- [ ] Extracted entities were explicitly classified.
+- [ ] Current terminology outside historical material.
+- [ ] Glossary reviewed and updated when required.
+- [ ] Changelog reviewed and updated when required.
+- [ ] No canonical concept redefined locally.
+- [ ] Examples are not universal requirements.
+- [ ] Responsibilities are not confused with mandatory titles.
+- [ ] Research, history, and reference material remain within their authority boundaries.
+- [ ] Controls include a real intervention path, not telemetry alone.
+- [ ] Metadata and tags agree with the content.
+- [ ] Internal links resolve.
+- [ ] No duplicate canonical entry point or namespace.
 - [ ] Moved or superseded material remains traceable.
-- [ ] Relevant module indexes and cross-references were reviewed.
-- [ ] Changelog and roadmap impact were considered.
-- [ ] Unresolved contradictions, assumptions, and evidence gaps are disclosed.
+- [ ] Module indexes and cross-references reviewed.
+- [ ] Roadmap impact reviewed.
+- [ ] Unresolved assumptions and evidence gaps disclosed.
 
 ## 13. Repository anti-patterns
 
-Avoid the following patterns of contribution:
-
 ### Duplicate doctrine
 
-Creating a second explanation of a canonical concept because the existing one is inconvenient, incomplete, or located elsewhere.
-
-Preferred response: refine the owning document and link to it.
+Creating a second explanation of a canonical concept. Refine the owning document and link to it.
 
 ### Local terminology
 
-Inventing a new name inside a pattern, reference architecture, or article for a concept already represented in the glossary.
-
-Preferred response: use the canonical term or propose an explicit glossary change.
+Inventing a new name inside a pattern or reference architecture for an existing concept. Use the glossary or propose an explicit glossary change.
 
 ### Accidental promotion
 
-Writing research findings, examples, or reference designs in language that makes them appear normative.
-
-Preferred response: preserve their status and create an explicit specification change when promotion is intended.
+Writing research or examples as if they were normative. Preserve status and make promotion explicit.
 
 ### Architecture by accumulation
 
-Adding more files to reconcile inconsistency instead of resolving ownership, status, or terminology.
-
-Preferred response: identify the canonical source and consolidate or supersede deliberately.
+Adding files to reconcile inconsistency. Resolve ownership, status, and terminology instead.
 
 ### Tool-as-control fallacy
 
-Treating an evaluator, guardrail, schema, dashboard, model, or workflow engine as a complete control system without authority and corrective action.
-
-Preferred response: describe the capability it provides and the missing parts of the loop.
+Treating a schema, evaluator, dashboard, guardrail, model, or workflow engine as a complete control system without authority and corrective action.
 
 ### Universal thresholds
 
-Copying illustrative numbers into requirements without deriving them from consequences, uncertainty, autonomy, reversibility, evidence quality, and context.
-
-Preferred response: describe how thresholds should be selected and label examples clearly.
+Copying illustrative numbers into requirements without risk- and context-derived justification.
 
 ### Historical normalization
 
-Rewriting old publications or records to match current terminology and doctrine.
-
-Preferred response: preserve the original and add current interpretation separately.
+Rewriting old publications to match current terminology. Preserve the original and annotate separately.
 
 ### Namespace proliferation
 
-Creating `new`, `v2`, `final`, `latest`, temporary top-level directories, or parallel canonical paths without an explicit repository decision.
+Creating `new`, `v2`, `final`, `latest`, or parallel canonical paths without an explicit decision.
 
-Preferred response: use status, version control, supersession notes, and the existing taxonomy.
+### Changelog omission
 
-### Publishing-driven authority
+Making a notable repository or specification-artifact change without updating `CHANGELOG.md` in the same branch and pull request.
 
-Allowing site navigation, generated pages, tags, or search behavior to redefine repository authority.
-
-Preferred response: keep the canonical boundary in `SPECIFICATION.md` and module indexes.
+Preferred response: add a concise entry under `[Unreleased]` that describes the repository-level effect.
 
 ## 14. Scope of this file
 
-`AGENTS.md` is the repository's tool-neutral operational protocol for AI-assisted contributors.
+`AGENTS.md` is the tool-neutral operational protocol for AI-assisted contributors.
 
-Tool-specific files such as `CLAUDE.md`, `.cursorrules`, or similar adapters should not duplicate this document. If a tool-specific adapter is required, it should point here and contain only the minimal tool-specific delta.
+Tool-specific adapters such as `CLAUDE.md` or `.cursorrules` should point here and contain only the minimal tool-specific delta.
 
-This file should evolve when repository structure, authority rules, terminology workflow, or contribution practice changes. It must not evolve into a parallel specification of UA itself.
+This file should evolve when repository structure, authority rules, terminology workflow, change-record policy, or contribution practice changes. It must not become a parallel specification of UA itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Project publications, talks, community discussions, and independent references a
 - Clarified that telemetry or evaluation becomes control only when connected to decision authority and a mechanism that can change, contain, roll back, escalate, or stop behavior.
 - Added controlled metadata to the specification, glossary, module entry points, Control Plane sub-documents, and actively maintained research indexes.
 - Updated contribution guidance to require consistent metadata for new maintained conceptual documents and to direct agent-assisted work through `AGENTS.md`.
+- Expanded `AGENTS.md` into an operational protocol that requires same-PR changelog updates and explicit classification of source-derived concepts, artifacts, responsibilities, processes, patterns, failure modes, and reference architectures.
 - Updated the roadmap so cross-publication synthesis is now the immediate substantive priority.
 
 ### Removed


### PR DESCRIPTION
## Summary

This follow-up draft adds the repository workflow rules needed for the next UA synthesis phase: extracting entities from the presentation and research sources, classifying them, placing them in the correct technical or socio-technical layer, and recording material changes in the changelog.

## What changed

- made `CHANGELOG.md` review mandatory at the end of every repository-changing session;
- requires material changes to be added under `[Unreleased]` in the same branch and pull request;
- added a `Changelog omission` anti-pattern;
- added source-entity classification for:
  - doctrine concepts and definitions;
  - technical artifacts;
  - roles and responsibility bundles;
  - processes and rituals;
  - technical reference artifacts;
  - patterns;
  - failure modes;
  - reference architectures;
- added a workflow for extracting candidate entities from talks, presentations, and research sources before promoting them into the specification;
- clarified that source material must be decomposed and classified rather than copied wholesale into doctrine;
- updated `CHANGELOG.md` to record the expanded `AGENTS.md` operational protocol.

## Why

The next substantive UA task is to structure the technical and socio-technical stack around artifacts, roles, processes, control capabilities, and reference artifacts. The agent guide now defines how source-derived entities should be evaluated and placed without creating duplicate doctrine or accidental normative claims.

## Review focus

- Are the source-entity classes sufficient for the upcoming presentation decomposition?
- Is the changelog rule strict enough for repository traceability without creating noise?
- Are artifact, role, process, pattern, and reference distinctions clear enough for consistent placement?

## Integrity check

- Glossary reviewed — no canonical terminology change required.
- `CHANGELOG.md` updated in the same change.
- No normative UA concept was promoted from the presentation by implication.
- No new top-level namespace was introduced.
