### PR TITLE
docs: clarify proportional source crystallization workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Project publications, talks, community discussions, and independent references a
 - Added controlled metadata to the specification, glossary, module entry points, Control Plane sub-documents, and actively maintained research indexes.
 - Updated contribution guidance to require consistent metadata for new maintained conceptual documents and to direct agent-assisted work through `AGENTS.md`.
 - Expanded `AGENTS.md` into an operational protocol that requires same-PR changelog updates and explicit classification of source-derived concepts, artifacts, responsibilities, processes, patterns, failure modes, and reference architectures.
+- Clarified the proportional research-review process with a concise source-extraction and framework-crystallization step, canonical ownership rules, executable-clarity guidance, and reuse of the existing traceability matrix rather than a second ledger.
 - Refined the canonical definitions of Requirement, Operating Envelope, Correctness, Bug, and Deviation Signal so statistical excursions remain evidence while a Bug is defined by violation of the approved operating contract.
 - Updated the roadmap so cross-publication synthesis is now the immediate substantive priority.
 

--- a/content/research/framework-traceability.md
+++ b/content/research/framework-traceability.md
@@ -31,12 +31,14 @@ It prevents two opposite errors:
 
 Traceability is a synthesis aid, not a mandatory ledger for every source or sentence.
 
+This matrix is the canonical repository record for material source-to-framework decisions. Do not create a parallel crystallization ledger elsewhere; detailed argument belongs in the supporting analysis, synthesis, or source-intake note.
+
 ## Status vocabulary
 
 - **Research Finding** — a conclusion preserved from research material.
 - **Candidate** — potentially suitable for translation into a framework component.
 - **Needs Resolution** — terminology, evidence, scope, or contradiction must be resolved first.
-- **Proposed for Framework Review** — mature enough for a separate normative proposal and visible review.
+- **Proposed for Framework Review** — mature enough for a separate, deliberate normative proposal and visible review.
 - **Active** — accepted into the normative framework.
 - **Superseded** — replaced by a later formulation.
 - **Rejected** — considered and intentionally not adopted.

--- a/content/research/review-process.md
+++ b/content/research/review-process.md
@@ -13,7 +13,7 @@ tags:
   - ua/status/informative
   - ua/topic/provenance
 created: 2026-07-24
-updated: 2026-07-26
+updated: 2026-07-30
 license: CC-BY-4.0
 ---
 
@@ -115,6 +115,40 @@ Research Source or Observation
 ```
 
 No step is automatic, and not every item requires every intermediate document.
+
+## Source extraction and framework crystallization
+
+When a source may change doctrine, patterns, control capabilities, reference architectures, failure modes, or reusable artifacts, perform an explicit crystallization pass before editing the specification.
+
+1. Preserve or register the source.
+2. Extract distinct candidate items rather than treating an article, slide, table, or diagram as one indivisible contribution.
+3. Classify each item as a term, doctrine-level distinction, pattern, artifact, control capability, evidence, example, responsibility, process, failure mode, reference-architecture element, or project-specific threshold.
+4. Check whether the item already has a canonical owner and whether the proposed wording is stronger than the evidence supports.
+5. Decide whether the item is retained, narrowed, generalized, split, rejected, or deferred.
+6. Place accepted items in their owning module and replace duplicate explanations with cross-references.
+7. Update [`framework-traceability.md`](framework-traceability.md) when the decision is material enough to require an auditable research-to-framework link.
+
+Use this default ownership rule:
+
+| Content | Canonical owner |
+|---|---|
+| Canonical term or concise meaning | `00-doctrine/glossary.md` |
+| Foundational distinction or invariant | `00-doctrine/` |
+| Reusable operational response, checklist, or gate | `01-patterns/` |
+| Control capability | `02-ai-control-plane/` |
+| Concrete composition | `03-reference-architectures/` |
+| Reusable mechanism of loss of control | `04-failure-modes/` |
+| Evidence, critique, or unresolved hypothesis | `content/research/` |
+| Historical wording or chronology | `content/history/` |
+| Original preserved source | `content/raw/` |
+
+The glossary defines what a canonical term means. Doctrine explains the foundational model. A pattern explains how a team applies that model. A reference architecture shows one possible composition.
+
+Do not move directly from source wording into normative specification. Do not duplicate full explanations across glossary, doctrine, patterns, and reference architectures. Do not dilute a clear operational procedure into abstract prose when a reusable executable pattern or artifact is the appropriate result.
+
+When the source contains an operational procedure, preserve its executable structure through the appropriate combination of inputs, outputs, entry and exit criteria, evidence, decision rights, checklists, tables, and explicit outcomes such as pass, block, limit, escalate, revise, roll back, or stop.
+
+Use Mermaid only when sequence, feedback, authority, state, ownership, or dependency structure is materially clearer as a diagram. The diagram and written rules must express the same model.
 
 ## Changes requiring deliberate framework review
 


### PR DESCRIPTION
## Summary

Clarifies how articles, presentations, talks, benchmarks, implementations, and other sources are translated into UA framework decisions without turning `AGENTS.md` into a second research-methodology document.

## What changed

- keeps the existing concise agent guidance in `AGENTS.md` unchanged;
- places the detailed source-extraction and framework-crystallization flow in `content/research/review-process.md`, which already owns the research-to-framework transition;
- adds a compact seven-step crystallization pass for material source-derived changes;
- defines a canonical ownership map for glossary, doctrine, patterns, Control Plane capabilities, reference architectures, failure modes, research, history, and raw sources;
- preserves operational source content as executable procedures rather than abstract prose;
- adds limited Mermaid guidance only where diagrams materially clarify structure;
- explicitly reuses `content/research/framework-traceability.md` instead of creating a second crystallization ledger;
- clarifies that the existing traceability matrix is the canonical repository record for material source-to-framework decisions;
- updates `CHANGELOG.md` in the same PR.

## Duplication removed from the original draft

The first version added a ten-step workflow, repeated classification rules, new end-of-session checks, several anti-patterns, and a second source-to-framework record inside `AGENTS.md`. That version was reset. The revised PR keeps one owning process document and one canonical traceability record.

## Files changed

- `content/research/review-process.md`
- `content/research/framework-traceability.md`
- `CHANGELOG.md`
