### PR TITLE
Restore README attribution, evidence, and citation guidance

### DIFF
--- a/.github/workflows/link-integrity.yml
+++ b/.github/workflows/link-integrity.yml
@@ -30,7 +30,7 @@ jobs:
         run: python3 ../.github/scripts/validate_navigation.py
 
       - name: Validate CITATION.cff
-        run: docker run --rm -v "${{ github.workspace }}:/app" citationcff/cffconvert:2.0.0@sha256:f8c5dc5fa8013e5c3635b1c2695bf54eac4d319719f8acdbb7b7ad7a778e46ea --validate
+        run: docker run --rm --network none -v "${{ github.workspace }}:/app:ro" citationcff/cffconvert:2.0.0@sha256:f8c5dc5fa8013e5c3635b1c2695bf54eac4d319719f8acdbb7b7ad7a778e46ea --validate
 
       - name: Validate maintained Markdown links and anchors
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0

--- a/.github/workflows/link-integrity.yml
+++ b/.github/workflows/link-integrity.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   internal-links:
-    name: Repository navigation, links, and anchors
+    name: Repository navigation, links, citations, and anchors
     runs-on: ubuntu-latest
 
     steps:
@@ -28,6 +28,9 @@ jobs:
       - name: Validate navigation coverage, order, and routing
         working-directory: 00-doctrine
         run: python3 ../.github/scripts/validate_navigation.py
+
+      - name: Validate CITATION.cff
+        run: docker run --rm -v "${{ github.workspace }}:/app" citationcff/cffconvert:2.0.0 --validate
 
       - name: Validate maintained Markdown links and anchors
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0

--- a/.github/workflows/link-integrity.yml
+++ b/.github/workflows/link-integrity.yml
@@ -30,7 +30,7 @@ jobs:
         run: python3 ../.github/scripts/validate_navigation.py
 
       - name: Validate CITATION.cff
-        run: docker run --rm -v "${{ github.workspace }}:/app" citationcff/cffconvert:2.0.0 --validate
+        run: docker run --rm -v "${{ github.workspace }}:/app" citationcff/cffconvert:2.0.0@sha256:f8c5dc5fa8013e5c3635b1c2695bf54eac4d319719f8acdbb7b7ad7a778e46ea --validate
 
       - name: Validate maintained Markdown links and anchors
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Publications, talks, community discussions, and independent references belong un
 
 ### Added
 
-- Added a root [`CITATION.cff`](CITATION.cff) so GitHub and compatible citation tools can expose machine-readable repository citation metadata for Vitalii Oborskyi and Sam Walker.
+- Added a root [`CITATION.cff`](CITATION.cff) so GitHub and compatible citation tools can expose machine-readable repository citation metadata for Vitalii Oborskyi and Sam Walker, and extended CI to validate that metadata against CFF schema 1.2.0.
 - Added a GitHub Actions CI workflow that validates the declared navigation coverage and destinations and uses a SHA-pinned `lychee` action in offline mode to check repository-relative links, directory indexes, Markdown heading fragments, and explicit HTML compatibility anchors across maintained Markdown without making external-network availability part of repository integrity.
 - Added a non-normative drafting-ready editorial contract and Phase 1 completion-candidate record for the planned public synthesis article, *Uncertainty Architecture: An Open Engineering Specification for Thinking Systems*. The proposed structure uses one unnumbered abstract, eight numbered sections, three figures, and one illustrative continuous Constraint trace; article prose has not begun and maintainer freeze remains pending.
 - Added draft-normative [`Control-Loop Capability Anatomy`](00-doctrine/control-loop-anatomy.md), distinguishing a closed feedback loop from a complete bounded UA control architecture.
@@ -92,7 +92,7 @@ Publications, talks, community discussions, and independent references belong un
 
 ### Fixed
 
-- Restored the root README sections for authors, maintainers, contributors, advisors, repository citation, and full dual-license guidance that were unintentionally dropped during landing-page simplification.
+- Restored the root README attribution, contributor, advisor, maturity, evidence, contribution, repository-citation, and full dual-license guidance that was unintentionally dropped during landing-page simplification.
 
 ### Moved and compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Publications, talks, community discussions, and independent references belong un
 
 ### Added
 
+- Added a root [`CITATION.cff`](CITATION.cff) so GitHub and compatible citation tools can expose machine-readable repository citation metadata for Vitalii Oborskyi and Sam Walker.
 - Added a GitHub Actions CI workflow that validates the declared navigation coverage and destinations and uses a SHA-pinned `lychee` action in offline mode to check repository-relative links, directory indexes, Markdown heading fragments, and explicit HTML compatibility anchors across maintained Markdown without making external-network availability part of repository integrity.
 - Added a non-normative drafting-ready editorial contract and Phase 1 completion-candidate record for the planned public synthesis article, *Uncertainty Architecture: An Open Engineering Specification for Thinking Systems*. The proposed structure uses one unnumbered abstract, eight numbered sections, three figures, and one illustrative continuous Constraint trace; article prose has not begun and maintainer freeze remains pending.
 - Added draft-normative [`Control-Loop Capability Anatomy`](00-doctrine/control-loop-anatomy.md), distinguishing a closed feedback loop from a complete bounded UA control architecture.
@@ -88,6 +89,10 @@ Publications, talks, community discussions, and independent references belong un
 - Replaced universal sample sizes, fixed thresholds, mandatory review cadences, and mandatory specialist titles with context-derived guidance.
 - Clarified that Golden Scenarios support regression and change detection rather than universal ground truth.
 - Clarified that telemetry or evaluation becomes control only when connected to reference conditions, decision authority, and an effective Actuator path.
+
+### Fixed
+
+- Restored the root README sections for authors, maintainers, contributors, advisors, repository citation, and full dual-license guidance that were unintentionally dropped during landing-page simplification.
 
 ### Moved and compatibility
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use Uncertainty Architecture, please cite the repository using the metadata below."
+title: "Uncertainty Architecture"
+type: generic
+authors:
+  - family-names: "Oborskyi"
+    given-names: "Vitalii"
+  - family-names: "Walker"
+    given-names: "Sam"
+date-released: 2025-12-09
+repository-code: "https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture"
+url: "https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture"
+license: "CC-BY-4.0"
+abstract: "An open engineering specification and pattern language for designing and operating Thinking Systems with explicit constraints, evidence, decision authority, and corrective action."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,14 +1,24 @@
 cff-version: 1.2.0
 message: "If you use Uncertainty Architecture, please cite the repository using the metadata below."
 title: "Uncertainty Architecture"
-type: generic
 authors:
   - family-names: "Oborskyi"
     given-names: "Vitalii"
   - family-names: "Walker"
     given-names: "Sam"
-date-released: 2025-12-09
+date-released: "2025-12-09"
 repository-code: "https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture"
 url: "https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture"
-license: "CC-BY-4.0"
 abstract: "An open engineering specification and pattern language for designing and operating Thinking Systems with explicit constraints, evidence, decision authority, and corrective action."
+preferred-citation:
+  type: generic
+  authors:
+    - family-names: "Oborskyi"
+      given-names: "Vitalii"
+    - family-names: "Walker"
+      given-names: "Sam"
+  title: "Uncertainty Architecture"
+  year: 2025
+  publisher:
+    name: "GitHub"
+  url: "https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture"

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Focus: project-management standards, organizational alignment, and the operation
 
 ### Otman Basir, Ph.D. — Academic Advisor
 
-Professor of Intelligent Systems at the University of Waterloo and author of the Social Responsibility Stack. His role supports the connection between control-theoretic research and practical engineering governance.
+Professor in the Department of Electrical and Computer Engineering at the University of Waterloo and author of the Social Responsibility Stack. His role supports the connection between control-theoretic research and practical engineering governance.
 
 - [LinkedIn](https://www.linkedin.com/in/otman-basir-ba1258178)
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For contribution and review guidance:
 
 ## Authors and Maintainers
 
-### Vitalii Oborskyi — Creator and Lead Architect
+### Vitalii Oborskyi — Creator, Lead Architect, and Maintainer
 
 Focus: operational framing, governance, delivery systems, adoption scaffolding, and system-level control.
 

--- a/README.md
+++ b/README.md
@@ -196,4 +196,61 @@ For contribution guidance:
 - [`DOCUMENT-METADATA.md`](DOCUMENT-METADATA.md)
 - [`content/research/review-process.md`](content/research/review-process.md)
 
-Documentation is licensed under CC BY 4.0. Code, where present, is licensed under Apache 2.0.
+## Authors and Maintainers
+
+### Vitalii Oborskyi — Creator and Lead Architect
+
+Focus: operational framing, governance, delivery systems, adoption scaffolding, and system-level control.
+
+- [LinkedIn](https://www.linkedin.com/in/vitaliioborskyi/)
+- [GitHub](https://github.com/oborskyivitalii)
+
+### Sam “stunspot” Walker — Technical Co-Author
+
+Focus: AI–code boundary placement, containment patterns, prompt-as-medium realism, and real-world failure modes.
+
+### Contributors and reviewers
+
+Additional contributors and reviewers are credited through [Git history and the contributors graph](https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture/graphs/contributors), merged pull requests, and attributed research or history records. Contribution guidance is maintained in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Advisors
+
+### Markus Kopko — Strategic Advisor on Governance and Alignment
+
+Focus: project-management standards, organizational alignment, and the operationalization of AI governance.
+
+- [LinkedIn](https://www.linkedin.com/in/markuskleinpmp/)
+
+### Otman Basir, Ph.D. — Academic Advisor
+
+Professor of Intelligent Systems at the University of Waterloo and author of the Social Responsibility Stack. His role supports the connection between control-theoretic research and practical engineering governance.
+
+- [LinkedIn](https://www.linkedin.com/in/otman-basir-ba1258178)
+
+Advisory relationships are part of the project's operating context. They do not imply institutional endorsement, certification, or formal adoption of UA. Supporting public evidence and precise claim boundaries are recorded in [`content/history/external-recognition.md`](content/history/external-recognition.md).
+
+## How to Cite
+
+GitHub can generate APA and BibTeX citations from the repository's machine-readable [`CITATION.cff`](CITATION.cff). The following BibTeX entry is the human-readable repository citation:
+
+```bibtex
+@misc{oborskyi_walker2025uncertainty,
+  author = {Oborskyi, Vitalii and Walker, Sam},
+  title = {Uncertainty Architecture},
+  year = {2025},
+  publisher = {GitHub},
+  url = {https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture},
+  note = {Open engineering specification for Thinking Systems}
+}
+```
+
+Individual articles and publications should be cited using their own publication metadata rather than this repository-level entry.
+
+## Licensing
+
+This repository uses a dual-license model:
+
+- documentation, specifications, architectural doctrine, diagrams, and operating-model material: CC BY 4.0;
+- code, scripts, reference implementations, and executable artifacts: Apache 2.0.
+
+See [`LICENSING.md`](LICENSING.md) for details.

--- a/README.md
+++ b/README.md
@@ -185,11 +185,23 @@ UA is a shared architectural language, a project-to-runtime control lifecycle, a
 
 UA is not an SDK, universal agent framework, prompt collection, single guardrail product, mandatory four-service topology, replacement SDLC, governance department, compliance certification, or claim that uncertainty can be eliminated.
 
-## Status and contribution
+## Status, Evidence, and Contributions
 
-The repository is an evolving open specification. Documents declare their own status and maturity. See [`SPECIFICATION.md`](SPECIFICATION.md).
+**Active specification development.** The current draft baseline connects the controlled-object doctrine, four capability families, project authorization, delivery realization and release, and runtime reassessment. A complete two-level worked application, real-team use, operational evidence, and further terminology validation remain open before a broader maturity claim. See [`ROADMAP.md`](ROADMAP.md).
 
-For contribution guidance:
+UA keeps different kinds of evidence separate:
+
+- [**Research**](content/research/) records sources, analysis, synthesis, and framework traceability.
+- [**Public discussions and stress tests**](content/history/community-discussions.md) record critique, alternatives, and unresolved questions.
+- [**Independent references and recognition**](content/history/external-recognition.md) record how third parties cited, interpreted, recommended, or used UA.
+- [**Talks and presentations**](content/history/talks.md) record practitioner exposure without treating invitations as technical validation.
+- The [**changelog**](CHANGELOG.md) records changes to repository and specification artifacts.
+
+Visibility, recommendations, advisory relationships, invited talks, and synthesized examples are not treated as certification, institutional endorsement, formal adoption, or production evidence. The evidence policy and complete historical index are maintained in [`content/history/`](content/history/).
+
+GitHub is the canonical home for doctrine and specification changes. Useful contributions include operational failure reports, worked applications, pattern proposals, critiques of terminology or control assumptions, evidence about Human Authority and control cost, and provenance corrections.
+
+For contribution and review guidance:
 
 - [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - [`AGENTS.md`](AGENTS.md)

--- a/content/history/external-recognition.md
+++ b/content/history/external-recognition.md
@@ -37,15 +37,17 @@ Michael Risch published a detailed interpretation of Uncertainty Architecture as
 
 ## Markus Kopko
 
-### Public recommendation and CPMAI mapping
+### Public recommendation, CPMAI mapping, and advisory context
 
 Markus Kopko, CPMAI Lead Coach and participant in PMI AI standards work, publicly recommended Vitalii Oborskyi’s contribution and described the Model Control Plane as a practical bridge between strategy and engineering reality.
 
 In May 2026, Kopko also published a detailed mapping between the UA control-theory framing and the CPMAI lifecycle, connecting constraints, sensors, named roles, and go/no-go gates to AI project governance.
 
-**What this establishes:** independent recognition from an AI project-governance practitioner and a concrete conceptual mapping between UA and CPMAI practices.
+UA records Kopko as a strategic advisor on governance and alignment. This project role is distinct from the public recommendation and CPMAI mapping documented here and does not imply PMI endorsement, certification, institutional adoption, or a formal relationship between PMI and UA.
 
-**What it does not establish:** formal PMI endorsement of UA.
+**What this establishes:** independent recognition from an AI project-governance practitioner, a concrete conceptual mapping between UA and CPMAI practices, and the project’s recorded advisory relationship.
+
+**What it does not establish:** formal PMI endorsement of UA or institutional participation in the project.
 
 - [Source: Markus Kopko — CPMAI mapping of UA](https://www.linkedin.com/posts/markuskleinpmp_uncertainty-architecture-why-ai-governance-activity-7462053122773827584-mKwf)
 - [Supporting source: Vitalii Oborskyi profile recommendation](https://www.linkedin.com/in/vitaliioborskyi/)


### PR DESCRIPTION
## Summary

This PR restores README attribution, contributor and advisor context, evidence and maturity boundaries, citation guidance, and the full dual-license summary that were unintentionally dropped during the PR #32 landing-page simplification.

It keeps the current compact landing-page architecture rather than restoring the older long-form README wholesale.

## Restored README functions

### Attribution and project roles

- **Authors and Maintainers**
  - Vitalii Oborskyi — Creator, Lead Architect, and Maintainer
  - Sam “stunspot” Walker — Technical Co-Author
- **Contributors and reviewers**
  - attribution through Git history, the contributors graph, merged pull requests, and attributed research/history records
- **Advisors**
  - Markus Kopko — Strategic Advisor on Governance and Alignment
  - Otman Basir, Ph.D. — Academic Advisor
  - explicit non-endorsement boundary

### Status, evidence, and contributions

- states that UA remains in active specification development;
- distinguishes the current draft baseline from open maturity work;
- restores links to research, public stress tests, independent references, talks, and the changelog;
- states that visibility, recommendations, advisory relationships, invited talks, and synthesized examples are not certification, institutional endorsement, formal adoption, or production evidence;
- restores the practical contribution invitation and keeps GitHub as the canonical home for accepted doctrine and specification changes.

### Citation and licensing

- adds a human-readable repository BibTeX citation;
- distinguishes repository citation from citation of individual publications;
- restores the complete dual-license summary linked to `LICENSING.md`.

The restored language is based on the last maintained README before PR #32, but current status wording is aligned to the present roadmap rather than copied from the older snapshot.

## Machine-readable citation

Adds root `CITATION.cff` using CFF 1.2 metadata for Vitalii Oborskyi and Sam Walker. The preferred citation uses `type: generic`, allowing citation tools to represent the repository as BibTeX `@misc` rather than only as computer software.

The existing integrity workflow now validates `CITATION.cff` with the official `citationcff/cffconvert:2.0.0` validator. The image is pinned by digest and runs without network access against a read-only repository mount.

## Evidence-ledger alignment

`content/history/external-recognition.md` now explicitly distinguishes Markus Kopko’s recorded UA advisory role from the public recommendation and CPMAI mapping retained as evidence. The record states that the role does not imply PMI endorsement, certification, institutional adoption, or a formal relationship between PMI and UA.

## Intentionally not restored

The following older README sections remain omitted because the current structure already replaces them more accurately:

- **Suggested Reader Path** — replaced by the global navigation block and numbered `Start Here` path;
- **The Core Shift** — now owned by `Uncertainty in the Controlled Object` and the current README rationale;
- the older three-family **Core Model** — superseded by the four-family Control-Loop Capability Anatomy;
- the long standalone **Nested Control Lifecycle** explanation — replaced by `Two Orthogonal Models`, the practical SMB path, and canonical doctrine links;
- the old detailed status inventory — replaced by a compact current maturity statement and `ROADMAP.md`.

## Files changed

- `README.md`
- `CITATION.cff`
- `.github/workflows/link-integrity.yml`
- `content/history/external-recognition.md`
- `CHANGELOG.md`

## Validation

- [x] Branch is based on the current merged `main` after PR #34.
- [x] README navigation and existing framework content remain unchanged.
- [x] Restored roles match prior maintained README and current attribution boundaries.
- [x] Advisor language preserves the non-endorsement disclaimer.
- [x] Markus Kopko’s advisory role and public evidence are distinguished explicitly.
- [x] Status and maturity language matches the current roadmap.
- [x] Evidence categories and claim boundaries match the current history namespace.
- [x] README BibTeX and `CITATION.cff` use the same authors, title, year, and URL.
- [x] `CITATION.cff` validates successfully against CFF schema 1.2.0.
- [x] Citation validation runs in a digest-pinned, network-disabled container with a read-only repository mount.
- [x] Navigation coverage and Markdown link/anchor checks pass.
- [x] Changelog records both the machine-readable citation and restored README functions.

The PR remains Draft for maintainer review.