### PR TITLE
Reframe the paper around Thinking Systems and bounded control

### DIFF
--- a/content/research/notes/open-engineering-specification-article-draft.md
+++ b/content/research/notes/open-engineering-specification-article-draft.md
@@ -33,6 +33,9 @@ source_basis:
   - ../../../00-doctrine/model-judgment-placement.md
   - ../../../00-doctrine/control-loop-anatomy.md
   - ../../../00-doctrine/nested-control-lifecycle.md
+  - ../../../01-patterns/project-control-architecture-and-viability-review.md
+  - ../../../01-patterns/thinking-system-review.md
+  - ../../../02-ai-control-plane/README.md
   - ../../../04-failure-modes/README.md
   - designing-nondeterministic-systems-source-intake.md
 ---
@@ -259,11 +262,230 @@ The next section begins with the first model. A system may be measured without b
 
 ## 3. From Model Quality to Bounded Control
 
-*Draft pending in the next article block.*
+A common response to probabilistic behavior is to improve measurement. Teams assemble test sets, run evaluators, inspect traces, monitor cost and latency, and compare model versions. This is necessary work. It can reveal regression, drift, weak grounding, unexpected tool use, or changes in business outcomes.
+
+Measurement, however, is not the same as control.
+
+A system can produce extensive evidence while nobody has authority to act on it. A review process can identify unacceptable behavior while no mechanism can prevent recurrence. An automated loop can detect degradation, select a response, and change the system while still permitting prohibited actions, exceeding delegated authority, or destroying the economics that justified the project.
+
+Control begins when evidence about a process reaches a decision function and an authorized action can affect the process again:
+
+```mermaid
+flowchart LR
+    R["Reference<br/>Requirement and intended conditions"]
+    P["Thinking System<br/>controlled process"]
+    S["Sensors and evidence"]
+    C["Controller and decision authority"]
+    A["Actuators"]
+
+    R --> C
+    P --> S --> C
+    C -->|authorized action| A
+    A -->|changes operation| P
+```
+
+**Figure 6 — A closed feedback loop.** Evidence reaches a decision function and an authorized action changes the controlled process. The figure does not yet show whether the loop operates inside an approved boundary.
+
+Closing the loop solves only part of the problem. The loop may optimize the wrong objective. It may respond too slowly for the consequence. Its Controller may possess authority that was never legitimately delegated. Its Actuator may change a prompt but be unable to block an external action. Its Sensor may observe average quality while missing a low-frequency prohibited state. The loop may keep a metric inside tolerance while Human Authority, fallback capacity, latency, or unit economics collapse.
+
+A complete UA control architecture therefore asks a broader question:
+
+> Is the feedback loop operating inside an approved and credibly realized boundary, with bounded authority, fit-for-purpose evidence, effective corrective action, and a valid path for reassessment?
+
+Four logical capability families answer different parts of that question.
+
+### Constraints and their realizations
+
+A **Constraint** is an approved condition limiting the allowed operating space. It may restrict reachable actions, side effects, authority, autonomy, data, tools, resources, deployment population, geography, or the conditions under which Human Authority is required.
+
+A Constraint is an authoritative decision object. It does not enforce itself.
+
+A **Constraint Realization** is the technical or socio-technical mechanism through which the Constraint is implemented, configured, enforced or influenced, evidenced, and operated for a defined scope. Permissions, typed interfaces, transaction guards, approval paths, prompts, evaluators, tool restrictions, isolation boundaries, rate limits, and manual procedures may all participate in realization.
+
+Constraint and Constraint Realization belong to one capability family because either one without the other is incomplete. A realization without an authoritative Constraint is a mechanism with no defensible boundary. A declared Constraint without realization is an intention with no operational effect. Constraint Realization is not a fifth capability family.
+
+Hard and Soft claims apply to a scoped Constraint together with its complete realized path. A **Hard Constraint** deterministically prevents or rejects violation within stated assumptions, subject, path, scope, and enforcement boundaries. A **Soft Constraint** influences probabilistic behavior but does not make the prohibited state unreachable.
+
+A prompt, natural-language policy, model preference, or probabilistic evaluator is not hard by itself. A permission boundary may support a Hard Constraint for one action path while the same business intent remains soft for generated wording. Those are different guarantees and should be recorded separately rather than hidden inside one ambiguous control claim.
+
+### Sensors and evidence
+
+**Sensors** produce evidence about behavior, outcomes, operating conditions, realization state, control health, Actuator execution, and the assumptions on which authorization depends.
+
+An evaluator usually performs a Sensor function. So do runtime telemetry, denied-action events, downstream outcomes, complaints, incidents, Human Authority response times, fallback load, and evidence that a realization is active or degraded.
+
+A Sensor need not produce one objective truth value. Semantic quality, harmfulness, usefulness, or business acceptability may remain uncertain. The requirement is that evidence be fit enough for a bounded decision and expose its coverage, uncertainty, latency, and blind spots.
+
+Telemetry without a decision path is observation. It may be valuable observation, but it is not control.
+
+### Controllers and decision authority
+
+A **Controller** compares or interprets evidence relative to approved Requirements, Constraints, assumptions, and a defined decision boundary, then selects or authorizes action.
+
+The Controller may be deterministic software, bounded automated decision logic, a human decision-maker, a review or incident process, or a distributed socio-technical responsibility. What makes it a Controller is not intelligence or automation. It is ownership of a defined decision and legitimate authority over the available response.
+
+Logic selecting `block`, `canary`, or `release` performs a Controller function. A dashboard does not become a Controller merely because a human views it. A human approval step is not substantive Human Authority unless the person has sufficient information, time, capacity, and power to change the outcome.
+
+### Actuators and corrective action
+
+An **Actuator** executes an authorized change in operation or in a Constraint Realization. It may block an action, narrow exposure, change routing, require Human Authority, switch to fallback, roll back a model or configuration, isolate a feature, compensate downstream state, or stop the system.
+
+A Controller decides or authorizes. An Actuator executes. One component may perform both functions, but collapsing the concepts hides decision rights, execution rights, failure behavior, and evidence about whether the selected action actually occurred.
+
+A Controller without an effective Actuator can diagnose but cannot correct. A kill-switch endpoint that nobody may legitimately invoke is not an operable response path. A feature flag that changes exposure is an Actuator only when it connects an authorized decision to a real operational change.
+
+The complete relationship is wider than a vertical stack or one synchronous pipeline:
+
+```mermaid
+flowchart LR
+    R["Authorized intent,<br/>Requirement, and assumptions"]
+    K["Constraints<br/>approved operating boundaries"]
+    KR["Constraint Realizations<br/>enforce or influence the boundary"]
+    P["Thinking System<br/>controlled process"]
+    S["Sensors and evidence<br/>behavior · outcomes · conditions<br/>realization and execution state"]
+    C["Controller and decision authority<br/>compare · interpret · authorize"]
+    A["Actuators<br/>execute authorized change"]
+
+    R --> C
+    R --> K
+    K --> KR
+    K -. defines decision boundary .-> C
+    K -. defines action boundary .-> A
+    KR -. enforces or influences .-> P
+    KR -. may gate .-> A
+    P --> S
+    KR -->|state, violations, and health| S
+    A -->|execution state and effects| S
+    S --> C
+    C -->|authorized action| A
+    A --> P
+    A -->|change within delegated authority| KR
+```
+
+**Figure 7 — Complete bounded UA control architecture.** The four capability families are logical functions, not mandatory services, products, teams, layers, or one execution order. Realizations may act before, during, or after Model Judgment; Controllers and Actuators may be synchronous or asynchronous; one component may perform several functions.
+
+The distinction matters because a loop can be technically closed and still unacceptable. UA does not ask only whether the system learns from feedback. It asks whether operation remains inside an approved, credibly realized, observable, and correctable boundary—and whether evidence can force reconsideration when that boundary or its assumptions no longer hold.
+
+The capability anatomy explains how bounded control functions. It does not yet say where organizational authority, project authorization, delivery release, runtime correction, and reassessment are owned. That is the role of the second orthogonal model.
 
 ## 4. Four Decision Levels of Uncertainty Architecture
 
-*Draft pending in the next article block.*
+The same capability functions appear at different decision horizons, but the decisions are not interchangeable.
+
+An organization may prohibit autonomous customer communication. A project may determine that a draft-only support workflow is viable under that boundary. A delivery team may implement permissions, tests, Human Authority, and fallback for one release. Runtime logic may reject an attempted send and disable the feature. These actions concern the same controlled object, but they operate with different authority, evidence, scope, and time horizon.
+
+UA separates four decision levels so that a lower-level response cannot silently rewrite the basis on which the system was authorized.
+
+### Two orthogonal models
+
+The **decision levels** identify where a decision is owned. The **capability families** identify how boundaries, evidence, decisions, and actions become operational. Every capability family may appear at every decision level. The models must not be mapped one-to-one.
+
+```mermaid
+flowchart LR
+    subgraph L["Decision ownership: where the decision belongs"]
+        O["Organization<br/>authoritative boundaries and decision rights"]
+        P["Project / architecture<br/>control architecture, viability, authorization"]
+        D["Delivery team<br/>realization, completeness, release"]
+        R["Runtime operation<br/>active control and reassessment"]
+
+        O -->|inherit sources and delegated authority| P
+        P -->|inherit project authorization and Constraints| D
+        D -->|deploy realized boundary and active versions| R
+        R -->|invalidating evidence| D
+        R -->|invalidating evidence| P
+        R -->|invalidating evidence| O
+    end
+
+    subgraph F["Capability functions: how control becomes operational"]
+        K["Constraints and realizations<br/>define and operationalize boundaries"]
+        S["Sensors and evidence<br/>observe behavior, conditions, and control state"]
+        C["Controllers and authority<br/>interpret evidence and authorize action"]
+        A["Actuators and action<br/>execute authorized change"]
+
+        K --- S
+        S --- C
+        C --- A
+    end
+
+    L -. "all four functions may appear at every level" .- F
+```
+
+**Figure 8 — Two orthogonal UA models.** Decision ownership flows downward through inherited authority and upward through reassessment. Capability families apply at every level. The figure does not prescribe sixteen components, four services, or a one-way lifecycle.
+
+### Organizational control context
+
+**Question owned:** Within which authoritative boundaries, shared capabilities, and decision rights may projects operate?
+
+The organizational level links the sources that already authorize or restrict the work: legal and contractual commitments, privacy and security requirements, procurement and vendor rules, geography, prohibited uses, approved deployment modes, incident obligations, shared capabilities, and exception authority.
+
+UA does not require a new organizational governance artifact or department by default. Existing sources should be linked rather than copied into parallel policy prose. A small company may hold this authority in a founder, product owner, technical leader, or existing legal or security responsibility.
+
+Authority at this level does not automatically create an operable technical guarantee. An organizational prohibition becomes a project Constraint only after it is interpreted for a defined subject, path, and scope. It becomes hard only where a complete realized path deterministically prevents or rejects violation within stated assumptions.
+
+Organizational change is required when the authoritative source, approved vendor or deployment mode, decision right, exception authority, or shared capability changes. Runtime evidence may trigger that review; runtime does not perform it automatically.
+
+### Project control architecture and viability
+
+**Question owned:** Does a credible, operable, and economically viable control architecture exist for this proposed Thinking System within a defined boundary?
+
+This is the architecture decision that must exist before a successful prototype is mistaken for an authorized project.
+
+The project review owns the intended outcome and the necessity of Model Judgment, the project boundary, material scenarios, Project Constraint Architecture, required control capabilities and assumptions, evidence feasibility, Human Authority, fallback and recovery, operating capacity, control economics, residual exposure, and the conditions for reauthorization.
+
+The question is not simply whether the model can perform the task. It is whether the complete controlled system can operate credibly and affordably. A design that requires more review capacity than the organization can provide, cannot detect violations before unacceptable harm, depends on an unrealizable Hard Constraint, or destroys the expected unit economics may be technically impressive and architecturally non-viable.
+
+Project outcomes may include authorization, narrowed scope, conditions, further research, redesign, deferral, escalation, or No-Go. **Architectural Veto** is a valid engineering result, not a failure of enthusiasm.
+
+The project level produces one versioned Project Constraint Architecture and authorization baseline. Delivery inherits that baseline by reference. It may refine and narrow it. It may not silently expand delegated authority or weaken an inherited Hard Constraint.
+
+### Delivery-level Thinking System Review
+
+**Question owned:** Is a bounded system, feature, or material change ready, complete, and acceptable for a specific deployment context under project authorization?
+
+Delivery turns project intent into a concrete realization. It identifies implementation-level Judgment Nodes, defines the delivery Requirement and Operating Envelope, maps inherited and local Constraints to one canonical Constraint Realization Map, implements or experiments within authority, produces evidence, and makes a deployment decision.
+
+Three decisions remain distinct.
+
+**Definition of Ready** establishes whether bounded work or an experiment may begin. The inherited authority, scope, Judgment Nodes, required realizations, evidence plan, Human Authority, fallback, assumptions, and escalation path must be explicit enough to proceed.
+
+**Definition of Done** establishes whether implementation and evidence are complete for the reviewed scope. Required paths are covered, unavailable and bypass behavior are tested, active versions are traceable, Sensors and Actuators are operational, and known gaps are visible.
+
+**Release Gate** accepts, limits, conditions, escalates, or rejects a deployment for a specific population and context. A system may satisfy DoD and still fail the Release Gate because evidence, capacity, residual risk, economics, or operational readiness are unacceptable.
+
+Delivery may repair a local realization, narrow exposure, roll back, or change configuration within delegated authority. It must request project reauthorization when new evidence changes the project risk, authority boundary, feasibility, evidence basis, Human Authority capacity, or economics.
+
+### Runtime operation and reassessment
+
+**Question owned:** Does active operation remain within the approved Requirement, Constraint baseline, authority, capacity, and economics, with required realizations active and healthy—and what action follows when it does not?
+
+Runtime is where the realized control architecture is exercised. It produces evidence about actual behavior and downstream outcomes, realization activation and bypass, drift, violations, false blocks, latency, cost, fallback load, Human Authority capacity, Actuator execution, and the assumptions inherited from project and organizational decisions.
+
+Runtime Controllers may select or authorize responses within their delegated boundary. Runtime Actuators may reject, contain, compensate, route to fallback, narrow exposure, roll back, disable, or stop operation. These actions can restore a known authorized state or limit harm. They do not automatically authorize a new project boundary.
+
+Evidence must route according to the decision basis it invalidates:
+
+```mermaid
+flowchart TB
+    E["Runtime evidence or requested change"]
+    L["Local implementation, realization,<br/>configuration, or evidence issue"]
+    P["Project risk, authority, feasibility,<br/>capacity, evidence, or economics changed"]
+    O["Authoritative source, decision right,<br/>or shared capability changed"]
+    X["Proposed expansion of authority"]
+
+    E --> L --> D[Delivery reassessment]
+    E --> P --> PR[Project reauthorization]
+    E --> O --> OR[Organizational review]
+    E --> X --> PR
+    PR -->|where organizational boundary must change| OR
+```
+
+**Figure 9 — Evidence and change routing.** The destination is determined by the basis of the decision being challenged or changed, not merely by where the signal first appears. A proposed authority expansion is not normalized as runtime tuning.
+
+This routing prevents two opposite failures. The first is escalation theater, where every runtime defect becomes a governance meeting. The second is silent authority drift, where repeated local fixes gradually change the project without an explicit architecture decision.
+
+The levels form a nested lifecycle rather than a waterfall. Higher-level authority and Constraints flow downward by reference and become more concrete in delivery and runtime realization. Evidence flows upward when it invalidates an earlier basis. Lower levels may refine and narrow. They may not silently expand authority, weaken an inherited Hard Constraint, or normalize evidence that the project is no longer viable.
+
+The capability anatomy and decision levels now define the conceptual center of UA. The next practical question is how a small team can preserve these distinctions without maintaining four governance processes and a cemetery of synchronized documents.
 
 ## 5. From Authority to Operation: Two Living Reviews
 

--- a/content/research/notes/open-engineering-specification-article-draft.md
+++ b/content/research/notes/open-engineering-specification-article-draft.md
@@ -45,6 +45,8 @@ source_basis:
 *From project viability to delivery realization, runtime evidence, and reauthorization*
 
 > **Draft status:** This article is being developed section by section from the repository's current draft specification. It is not itself a normative specification source.
+>
+> **Cumulative drafting rule:** Every subsequent section must be developed from the accepted blueprint **and** all previously accepted article sections, claims, transitions, and figures. Later prose must continue the existing line of argument rather than treating the blueprint as an isolated checklist or re-deriving the framework from scratch.
 
 ## Abstract
 
@@ -418,7 +420,34 @@ flowchart LR
 
 The organizational level links the sources that already authorize or restrict the work: legal and contractual commitments, privacy and security requirements, procurement and vendor rules, geography, prohibited uses, approved deployment modes, incident obligations, shared capabilities, and exception authority.
 
-UA does not require a new organizational governance artifact or department by default. Existing sources should be linked rather than copied into parallel policy prose. A small company may hold this authority in a founder, product owner, technical leader, or existing legal or security responsibility.
+The organizational question is not limited to identifying policy sources. The organization must determine which existing functions have legitimate influence over the Thinking System, which decisions each function owns, what evidence each requires, and which escalation or exception paths apply. Depending on the use case, the relevant functions may include product, engineering, architecture, operations, security, privacy, legal, compliance, procurement, finance, customer support, domain specialists, and executive authority.
+
+This does not mean that every department participates in every decision. It means that material dependencies and decision rights are explicit before they are needed. Security may own an identity boundary, legal a contractual prohibition, finance the acceptance of control economics, operations a shutdown capability, and a domain function the Human Authority required to interpret ambiguous cases. A system becomes ungovernable when these functions influence it informally while their authority, evidence obligations, and response commitments remain undefined.
+
+UA does not require a new organizational governance artifact or department by default. Existing sources should be linked rather than copied into parallel policy prose. A small company may assign several responsibilities to the same people. The requirement is explicit authority and accountability, not organizational ceremony.
+
+```mermaid
+flowchart LR
+    TS["Thinking System proposal and operation"]
+    PROD["Product and business authority<br/>outcome · value · acceptable exposure"]
+    ENG["Engineering and architecture<br/>system boundary · feasibility · realization"]
+    OPS["Operations<br/>runtime capability · incident response · shutdown"]
+    SEC["Security, privacy, legal, compliance<br/>authoritative restrictions · evidence · exceptions"]
+    FIN["Finance and procurement<br/>vendor, capacity, and control economics"]
+    DOM["Domain function / Human Authority<br/>contextual judgment · escalation · review capacity"]
+    RIGHTS["Explicit decision rights,<br/>dependencies, and escalation paths"]
+
+    PROD --> RIGHTS
+    ENG --> RIGHTS
+    OPS --> RIGHTS
+    SEC --> RIGHTS
+    FIN --> RIGHTS
+    DOM --> RIGHTS
+    RIGHTS --> TS
+    TS -->|evidence and changed assumptions| RIGHTS
+```
+
+**Figure 9 — Organizational influence architecture.** The organization identifies which existing functions legitimately shape the system and what each owns. The figure does not prescribe departments, committees, or one participant per function; several responsibilities may be combined in a small organization.
 
 Authority at this level does not automatically create an operable technical guarantee. An organizational prohibition becomes a project Constraint only after it is interpreted for a defined subject, path, and scope. It becomes hard only where a complete realized path deterministically prevents or rejects violation within stated assumptions.
 
@@ -430,9 +459,45 @@ Organizational change is required when the authoritative source, approved vendor
 
 This is the architecture decision that must exist before a successful prototype is mistaken for an authorized project.
 
+Before substantial implementation begins, the project should be able to describe at least one complete and credible control loop for each material scenario. This does not require final production configuration, but it requires more than a list of controls to be added later. The project must identify the intended Requirement and Operating Envelope, material risks and reachable consequences, scoped Constraints, candidate Constraint Realizations, evidence needed to detect loss of acceptable operation, Controller authority, effective Actuator paths, Human Authority and fallback where required, expected feedback latency, and the assumptions under which the loop can work.
+
 The project review owns the intended outcome and the necessity of Model Judgment, the project boundary, material scenarios, Project Constraint Architecture, required control capabilities and assumptions, evidence feasibility, Human Authority, fallback and recovery, operating capacity, control economics, residual exposure, and the conditions for reauthorization.
 
+The cost of the control perimeter belongs in viability from the beginning. Evaluation, observability, semantic review, Human Authority, fallback capacity, incident response, model and vendor dependencies, control maintenance, and expected operational friction are not post-launch overhead accidentally discovered after the prototype succeeds. They are part of the architecture and economics of the proposed system.
+
 The question is not simply whether the model can perform the task. It is whether the complete controlled system can operate credibly and affordably. A design that requires more review capacity than the organization can provide, cannot detect violations before unacceptable harm, depends on an unrealizable Hard Constraint, or destroys the expected unit economics may be technically impressive and architecturally non-viable.
+
+```mermaid
+flowchart TB
+    OUT["Intended outcome and need for Model Judgment"]
+    RISK["Material scenarios<br/>reachable authority · consequences · uncertainty"]
+    K["Project Constraint Architecture<br/>approved boundaries and assumptions"]
+    LOOP["Credible complete control loop<br/>realizations · Sensors · Controllers · Actuators"]
+    HUMAN["Human Authority, fallback,<br/>containment, and recovery"]
+    ECON["Control economics<br/>latency · capacity · operating friction · vendor cost"]
+    DEC["Project decision<br/>authorize · narrow · research · redesign · defer · No-Go"]
+
+    OUT --> RISK --> K --> LOOP
+    LOOP --> HUMAN
+    LOOP --> ECON
+    HUMAN --> DEC
+    ECON --> DEC
+    DEC -. invalidating evidence requires reauthorization .-> RISK
+```
+
+**Figure 10 — Project control architecture and viability.** Project authorization requires a credible model of the complete control perimeter and its cost before the production path is authorized. The figure permits bounded research when the loop is not yet sufficiently understood; research authorization is not production authorization.
+
+#### Designing the control architecture
+
+Project authorization depends on architecture work that translates material business and operational risks into a realizable control structure.
+
+Architectural analysis identifies where Model Judgment is placed, what authority and consequences are reachable from each Judgment Node, which deterministic responsibilities must surround it, and which scenarios could produce unacceptable outcomes. From that analysis the project derives required Constraints, candidate Constraint Realizations, Sensor evidence, Controller decisions, Actuator paths, Human Authority, fallback, containment, recovery, and reassessment mechanisms.
+
+Sensor design must reflect the property being controlled. Machine-checkable or syntactic evidence may verify schema, type, structure, permissions, tool arguments, state transitions, resource limits, or other deterministic conditions. Semantic evidence may estimate grounding, relevance, harmfulness, intent alignment, factual support, policy meaning, or downstream business acceptability. Semantic Sensors remain probabilistic and must expose coverage, uncertainty, latency, and blind spots rather than being treated as oracles.
+
+Human participation, where required, is part of the system architecture rather than an external safety decoration. The design must account for the information available to the person, the decision they own, the time available, expected volume, expertise, fatigue, escalation rights, and what happens when Human Authority is unavailable or overloaded.
+
+The resulting architecture is driven by the risks, authority, and consequences of the system. UA does not require every project to deploy every possible control component.
 
 Project outcomes may include authorization, narrowed scope, conditions, further research, redesign, deferral, escalation, or No-Go. **Architectural Veto** is a valid engineering result, not a failure of enthusiasm.
 
@@ -443,6 +508,26 @@ The project level produces one versioned Project Constraint Architecture and aut
 **Question owned:** Is a bounded system, feature, or material change ready, complete, and acceptable for a specific deployment context under project authorization?
 
 Delivery turns project intent into a concrete realization. It identifies implementation-level Judgment Nodes, defines the delivery Requirement and Operating Envelope, maps inherited and local Constraints to one canonical Constraint Realization Map, implements or experiments within authority, produces evidence, and makes a deployment decision.
+
+Delivery readiness concerns the team's capability as well as the implementation. The delivery responsibility must understand how deterministic responsibilities and Model Judgment are separated; how Constraints become realizations; how behavioral evidence is produced; how changes in model, prompt, context, retrieval, tools, data, evaluators, configuration, and population can create drift; and how corrective actions remain inside delegated authority.
+
+This does not require every team member to become a control theorist or AI-safety specialist. It requires the team as a whole to cover the necessary responsibilities: architecture, implementation, deterministic verification, semantic evaluation, release decisions, observability, runtime operation, Human Authority, and escalation.
+
+The team must also translate in both directions. Technical signals such as evaluator regression, distribution change, prompt-version drift, increased override rate, fallback saturation, denied-action events, rising review latency, or realization degradation do not become useful project evidence until their business consequence is understood. Conversely, statements such as customer-trust risk, unacceptable financial exposure, or legal concern do not become operable engineering inputs until they are translated into scoped scenarios, Constraints, evidence requirements, authority boundaries, and response paths.
+
+```mermaid
+flowchart LR
+    BR["Business intent, risk, and authority<br/>value · prohibited consequences · acceptable exposure"]
+    ENG["Engineering translation<br/>scenarios · Constraints · realizations · evidence · response paths"]
+    IMP["Delivery implementation<br/>Judgment Nodes · tests · evaluators · telemetry · Actuators"]
+    TECH["Technical evidence<br/>drift · regressions · overrides · latency · capacity · incidents"]
+    BEXP["Business interpretation<br/>changed exposure · viability · authority · customer impact"]
+
+    BR --> ENG --> IMP --> TECH --> BEXP
+    BEXP -->|reassess, narrow, redesign, or escalate| ENG
+```
+
+**Figure 11 — Delivery translation loop.** The team converts business risks and authority into an operable control design, then converts technical evidence back into business exposure and decision consequences. The figure describes a responsibility of the delivery system, not a reporting handoff between two isolated groups.
 
 Three decisions remain distinct.
 
@@ -458,9 +543,29 @@ Delivery may repair a local realization, narrow exposure, roll back, or change c
 
 **Question owned:** Does active operation remain within the approved Requirement, Constraint baseline, authority, capacity, and economics, with required realizations active and healthy—and what action follows when it does not?
 
-Runtime is where the realized control architecture is exercised. It produces evidence about actual behavior and downstream outcomes, realization activation and bypass, drift, violations, false blocks, latency, cost, fallback load, Human Authority capacity, Actuator execution, and the assumptions inherited from project and organizational decisions.
+Runtime is where the realized control architecture is exercised. Monitoring must cover the active controlled system rather than only the model. Relevant evidence may include model behavior, downstream outcomes, active model and prompt versions, context and retrieval state, tool use, authorization failures, Constraint Realization activation and bypass, machine-checkable and semantic evidence, drift, complaints, overrides, Human Authority capacity, fallback load, cost, latency, incidents, Actuator execution, and whether corrective action produced the intended state.
+
+Monitoring becomes control only when a signal is tied to a decision. Material evidence should have an interpretation boundary, expected decision latency, responsible Controller, available Actuator, and escalation or reassessment route. A dashboard that accumulates signals without these connections is an observability surface, not a complete runtime control system.
 
 Runtime Controllers may select or authorize responses within their delegated boundary. Runtime Actuators may reject, contain, compensate, route to fallback, narrow exposure, roll back, disable, or stop operation. These actions can restore a known authorized state or limit harm. They do not automatically authorize a new project boundary.
+
+Runtime control must distinguish restoration from redesign. Rolling back, narrowing exposure, blocking an action, or switching to fallback may return the system to a previously authorized state. Persistent drift, changed business exposure, unsustainable Human Authority load, loss of Sensor validity, or broken control economics may require delivery reassessment or project reauthorization rather than another local tuning cycle.
+
+```mermaid
+flowchart LR
+    SYS["Active Thinking System<br/>models · prompts · context · tools · people · realizations"]
+    OBS["Runtime evidence<br/>behavior · outcomes · drift · control health · capacity · cost"]
+    CTRL["Runtime Controller<br/>interpret within delegated authority"]
+    ACT["Runtime Actuator<br/>reject · contain · fallback · narrow · roll back · stop"]
+    REST["Restored authorized state"]
+    ESC["Invalidated basis<br/>delivery reassessment or project reauthorization"]
+
+    SYS --> OBS --> CTRL
+    CTRL -->|local authorized correction| ACT --> REST --> SYS
+    CTRL -->|basis no longer valid| ESC
+```
+
+**Figure 12 — Runtime control and reassessment.** Runtime observes the complete socio-technical system, not only model outputs. Local action may restore an authorized state; persistent invalidation routes upward rather than silently redesigning the project in production.
 
 Evidence must route according to the decision basis it invalidates:
 
@@ -479,7 +584,7 @@ flowchart TB
     PR -->|where organizational boundary must change| OR
 ```
 
-**Figure 9 — Evidence and change routing.** The destination is determined by the basis of the decision being challenged or changed, not merely by where the signal first appears. A proposed authority expansion is not normalized as runtime tuning.
+**Figure 13 — Evidence and change routing.** The destination is determined by the basis of the decision being challenged or changed, not merely by where the signal first appears. A proposed authority expansion is not normalized as runtime tuning.
 
 This routing prevents two opposite failures. The first is escalation theater, where every runtime defect becomes a governance meeting. The second is silent authority drift, where repeated local fixes gradually change the project without an explicit architecture decision.
 


### PR DESCRIPTION
## Summary

Reframes the article so it first introduces and develops **Thinking Systems** as the engineering category, derives the problems created by consequential probabilistic Model Judgment, and postpones the introduction of **Uncertainty Architecture** until the final section.

The public article no longer contains internal drafting notes or repository-process instructions.

## Central argument

```text
engineering expands around consequential uncertainty
→ Thinking Systems place probabilistic Model Judgment inside the controlled object
→ Thinking Systems are not synonymous with agentic applications
→ model quality and observability are necessary but insufficient
→ bounded operation requires Constraints, Sensors, Controllers, and Actuators
→ decisions remain distinct across organization, project / architecture, delivery, and runtime
→ living reviews and a full lifecycle trace make the model operational
→ only then is Uncertainty Architecture introduced as an open specification organizing the result
```

## Thinking Systems definition

The article now uses the repository's canonical definition:

> A software system whose runtime behavior depends partly on probabilistic Model Judgment while consequential deterministic responsibilities, Constraints, decision rights, evidence, and corrective mechanisms remain explicit.

It explicitly distinguishes the category from agentic software:

- agentic systems are a higher-autonomy subset of Thinking Systems;
- a non-agentic feature may still be a Thinking System when probabilistic judgment materially affects interpretation, routing, decisions, outputs, or downstream action;
- an agentic workflow may remain largely linear where relevant routes, decisions, and authority are explicitly encoded.

## Structural changes

- removes the publication-facing subtitle about project viability and reauthorization;
- removes `Draft status` and `Cumulative drafting rule` from article prose;
- changes the paper title to `Thinking Systems: Engineering Software That Produces Consequential Judgment`;
- introduces Thinking Systems and Model Judgment in Section 1;
- adds a system-category Mermaid diagram;
- removes early promotional framing around Uncertainty Architecture;
- renames Section 4 to `Four Decision Levels for Thinking Systems`;
- removes UA branding from the capability and decision-level argument;
- reserves Section 8 for introducing Uncertainty Architecture after the engineering argument has been established;
- retains and renumbers all existing architecture diagrams.

## Current drafted sections

1. Engineering Evolves Around Dominant Uncertainty
2. The Controlled Object Has Changed
3. From Model Quality to Bounded Control
4. Four Decision Levels for Thinking Systems

## Review focus

- whether the definition of Thinking Systems is clear and sufficiently distinct from agentic applications;
- whether the paper now reads as an engineering argument rather than framework promotion;
- whether Uncertainty Architecture is deferred far enough without making the final introduction feel disconnected;
- whether the new category diagram avoids implying that all agentic software is probabilistic in the relevant sense;
- whether the existing capability and decision-level diagrams remain coherent after removing early UA branding.

## Scope boundary

This PR changes article prose only. It does not change the canonical glossary definition, doctrine, specification authority, research state, roadmap, or framework terminology.

<!-- ua-change-contract
{
  "change_class": "research",
  "owning_paths": [
    "content/research/notes/open-engineering-specification-article-draft.md"
  ],
  "decision_levels": ["organization", "project", "delivery", "runtime"],
  "capability_families": ["constraints", "sensors", "controllers", "actuators"],
  "terminology_impact": "unchanged",
  "research_state": "unchanged",
  "compatibility": "preserved",
  "changelog": "not-required",
  "glossary": "unchanged",
  "roadmap": "unchanged",
  "traceability": "unchanged"
}
-->