### PR TITLE
Correct Figure 3 and Figure 6 Mermaid layouts

### DIFF
--- a/content/research/notes/open-engineering-specification-article-blueprint.md
+++ b/content/research/notes/open-engineering-specification-article-blueprint.md
@@ -372,7 +372,7 @@ The reader should leave able to explain:
 
 **Primary Figure 1 — Controlled-object shift**
 
-Use a horizontal, side-by-side comparison of responsibility structures, not stacked panels and not one mandatory execution path.
+Use two vertical top-to-bottom responsibility diagrams placed side by side. The comparison must read as two parallel columns, not as two horizontal execution pipelines and not as one mandatory topology.
 
 ```text
 Left — Primarily explicitly encoded runtime behavior
@@ -389,15 +389,9 @@ external, requirement, delivery, and operational uncertainty
 → observed outputs, actions, and downstream outcomes
 ```
 
-Add one visually distinct callout, preferably using a restrained red treatment, that states the structural addition:
+Carry the visual distinction inside the Thinking System column itself. Do not add a separate callout node that competes with the two-column comparison or changes the apparent topology.
 
-```text
-What Thinking Systems add:
-consequential probabilistic Model Judgment
-inside the controlled object
-```
-
-The callout and Judgment Nodes may share the red visual treatment. The rest of the Thinking System boundary should remain visually distinct but must not be rendered as wholly probabilistic or inherently unsafe.
+Use restrained red treatment on the blocks whose responsibility changes because Model Judgment is present: the deterministic responsibility before judgment, the Judgment Node itself, and deterministic validation, authority, and execution after judgment. The external-input and final-output blocks and the Thinking System boundary itself should remain neutral. Red must identify the structural change, not imply that the whole Thinking System is probabilistic, unsafe, or erroneous.
 
 The figure must not imply that:
 
@@ -413,7 +407,7 @@ The figure must not imply that:
 
 - functional placement of Model Judgment, with **Model Judgment** above and **Input Interpretation**, **Decision Logic**, and **Output Mediation** aligned horizontally beneath it;
 - connected locations of requirement, operational, and runtime-judgment uncertainty;
-- one controlled object viewed across four decision horizons.
+- one controlled object viewed across four decision horizons, rendered as one centered vertical column in the canonical order Organization → Project / Architecture → Delivery → Runtime.
 
 The Model Judgment placement figure is a taxonomy, not a sequence. It must not connect the three placement categories laterally in a way that implies a mandatory pipeline.
 
@@ -910,7 +904,7 @@ Label the figure as an illustrative editorial synthesis, not application evidenc
 
 The three primary architectural figures are:
 
-1. **Controlled-object shift** — horizontal side-by-side comparison of responsibility structures, with a restrained red callout and matching Judgment Node treatment identifying consequential probabilistic Model Judgment as the structural addition inside the controlled object.
+1. **Controlled-object shift** — two vertical top-to-bottom responsibility diagrams placed side by side, with restrained red treatment on the changed responsibility blocks in the Thinking System column.
 2. **Two orthogonal models** — decision levels with downward inheritance and upward reassessment beside capability families applying at every level.
 3. **K-SEND-01 Constraint trace** — illustrative source-to-runtime path with delivery reassessment, Project Reauthorization, and separate authority expansion.
 
@@ -920,7 +914,7 @@ Supporting figures currently expected:
 - Thinking Systems category boundary;
 - Model Judgment placement, with Model Judgment above and the three placement categories in one horizontal row beneath it;
 - connected uncertainty locations;
-- one controlled object across four decision horizons;
+- one controlled object across four decision horizons, with all four horizon blocks centered in one vertical line;
 - closed feedback loop;
 - complete bounded control architecture;
 - organizational influence architecture;
@@ -1041,8 +1035,9 @@ Every article-writing PR must satisfy all of the following:
 - [ ] The abstract does not narrate the article's reveal sequence or contain internal editorial commentary.
 - [ ] Governance is framed as becoming operational through the active socio-technical control architecture rather than as a post-hoc review, document, or exact synonym for every control element.
 - [ ] The consequence of an incomplete cross-level control architecture is explicit, scoped to consequential production release of Thinking Systems, and visually emphasized once as a central engineering thesis without duplicating the argument.
-- [ ] Figure 3 is a horizontal side-by-side comparison and visually isolates consequential probabilistic Model Judgment as the structural addition without implying that the entire Thinking System is probabilistic.
+- [ ] Figure 3 places two vertical top-to-bottom responsibility diagrams side by side and uses restrained red treatment on the changed Thinking System blocks without implying that the entire system is probabilistic.
 - [ ] Figure 4 places Model Judgment above Input Interpretation, Decision Logic, and Output Mediation, with the three placements aligned horizontally and no implied mandatory sequence.
+- [ ] Figure 6 centers Organization, Project / Architecture, Delivery, and Runtime in one vertical line and preserves their canonical order.
 - [ ] The decision-horizon bridge uses short bold-labeled paragraphs and keeps control-architecture design inside the project / architecture level.
 - [ ] Every major new argument has an appropriate figure or an explicit reason why prose is clearer.
 - [ ] All figures were reviewed as one visual sequence and renumbered consistently.

--- a/content/research/notes/open-engineering-specification-article-draft.md
+++ b/content/research/notes/open-engineering-specification-article-draft.md
@@ -157,7 +157,7 @@ The architectural difference can be shown without pretending that conventional s
 ```mermaid
 flowchart LR
     subgraph A["Primarily explicitly encoded runtime responsibility"]
-        direction LR
+        direction TB
         A1[External input and operating conditions]
         A2[Deterministic decision and action responsibilities]
         A3[Output, action, or downstream state]
@@ -165,28 +165,22 @@ flowchart LR
     end
 
     subgraph B["Thinking System boundary"]
-        direction LR
+        direction TB
         B1[External input and operating conditions]
-        B2[Deterministic responsibilities]
-        J1["Judgment Node<br/>probabilistic Model Judgment"]
+        B2[Deterministic responsibilities before Model Judgment]
+        J1["One or more Judgment Nodes<br/>probabilistic Model Judgment"]
         B3[Deterministic validation, authority, and execution]
-        J2["Optional additional<br/>Judgment Node"]
         B4[Output, action, or downstream state]
-
         B1 --> B2 --> J1 --> B3 --> B4
-        B3 -. optional composition .-> J2 -.-> B4
     end
 
-    SHIFT["What Thinking Systems add<br/>consequential probabilistic Model Judgment<br/>inside the controlled object"]
-    SHIFT -.-> J1
-    SHIFT -.-> J2
-
-    classDef shift fill:#ffebee,stroke:#c62828,stroke-width:2px,color:#7f0000;
-    class SHIFT,J1,J2 shift;
-    style B fill:#fffafa,stroke:#c62828,stroke-width:2px
+    classDef changed fill:#ffebee,stroke:#c62828,stroke-width:2px,color:#7f0000;
+    classDef judgment fill:#ffcdd2,stroke:#b71c1c,stroke-width:3px,color:#6a0000;
+    class B2,B3 changed;
+    class J1 judgment;
 ```
 
-**Figure 3 — The controlled-object shift.** The two responsibility structures are shown side by side. On the left, consequential runtime behavior is produced primarily through explicitly encoded deterministic responsibilities. On the right, a Thinking System remains a mixed system, but probabilistic Model Judgment enters the controlled object through one or more Judgment Nodes. The red-highlighted elements identify the structural addition; they do not imply that the rest of the Thinking System is probabilistic or that every system follows this topology.
+**Figure 3 — The controlled-object shift.** Two vertical responsibility structures are placed side by side for direct comparison. On the left, consequential runtime behavior is produced through an explicitly encoded deterministic chain. On the right, a Thinking System remains mixed, but the internal responsibility structure changes: deterministic responsibilities surround one or more bounded Judgment Nodes, and deterministic validation, authority, and execution remain explicit after them. The red-highlighted blocks identify the responsibilities introduced or structurally changed by the presence of Model Judgment; they do not imply that the whole Thinking System is probabilistic or unsafe.
 
 Model Judgment can affect a workflow through several functional placements.
 
@@ -261,18 +255,14 @@ Yet the levels are structurally connected because they control the same object.
 
 ```mermaid
 flowchart TB
-    O["Organizational control context<br/>What boundaries and decision rights apply?"]
-    P["Project control architecture and viability<br/>Can a credible and viable controlled system exist?"]
-    D["Delivery realization and release<br/>Is this bounded implementation ready and acceptable?"]
-    R["Runtime operation and reassessment<br/>Does active operation remain inside the authorized conditions?"]
+    O["Organization level<br/>authoritative boundaries, shared capabilities,<br/>prohibited uses, and decision rights"]
+    P["Project / architecture level<br/>technical credibility, operational supportability,<br/>economic viability, and control architecture"]
+    D["Delivery level<br/>bounded realization, evidence,<br/>release decision, and corrective readiness"]
+    R["Runtime level<br/>active behavior, operating conditions,<br/>correction, escalation, and reassessment"]
 
     O -->|authoritative sources, shared capabilities, delegated authority| P
     P -->|Project Constraint Architecture and authorized boundary| D
     D -->|realized controls, release scope, active versions| R
-
-    R -->|local defect or implementation evidence| D
-    R -->|risk, authority, capacity, evidence, or economics invalidated| P
-    R -->|source, decision right, or shared capability changed| O
 ```
 
 **Figure 6 — One controlled object across four decision horizons.** Authority and Constraints flow downward by reference and become more concrete in realization. Evidence flows upward when it invalidates the basis of an earlier decision.


### PR DESCRIPTION
## Summary

Corrects the Mermaid composition of Figure 3 and Figure 6 after review of the rendered article.

## Manuscript changes

- changes Figure 3 into two vertical top-to-bottom responsibility diagrams placed side by side;
- keeps the conventional responsibility chain neutral;
- highlights the structurally changed Thinking System blocks in restrained red: deterministic responsibility before Model Judgment, the Judgment Node, and deterministic validation / authority / execution after it;
- removes the separate red callout block that distorted the comparison;
- changes Figure 6 into one centered vertical sequence in the canonical order Organization → Project / Architecture → Delivery → Runtime.

## Blueprint changes

- records the corrected Figure 3 composition as two vertical parallel columns;
- defines which Thinking System blocks receive red treatment and which remain neutral;
- records Figure 6 as one centered vertical column;
- adds matching figure-contract and acceptance criteria.

## Files

- `content/research/notes/open-engineering-specification-article-draft.md`
- `content/research/notes/open-engineering-specification-article-blueprint.md`

## Scope boundary

This PR changes only article diagrams, their captions, and the corresponding editorial contracts. It does not change doctrine, canonical terminology, decision levels, capability families, glossary, roadmap, or specification authority.

<!-- ua-change-contract
{
  "change_class": "research",
  "owning_paths": [
    "content/research/notes/open-engineering-specification-article-blueprint.md",
    "content/research/notes/open-engineering-specification-article-draft.md"
  ],
  "decision_levels": ["organization", "project", "delivery", "runtime"],
  "capability_families": ["constraints", "sensors", "controllers", "actuators"],
  "terminology_impact": "unchanged",
  "research_state": "unchanged",
  "compatibility": "preserved",
  "changelog": "not-required",
  "glossary": "unchanged",
  "roadmap": "unchanged",
  "traceability": "unchanged"
}
-->