### PR TITLE
fix(research): refine Section 2 figure layouts

### DIFF
--- a/content/research/notes/open-engineering-specification-article-blueprint.md
+++ b/content/research/notes/open-engineering-specification-article-blueprint.md
@@ -424,9 +424,11 @@ The figure must not imply that:
 
 - functional placement of Model Judgment, with **Model Judgment** above and **Input Interpretation**, **Decision Logic**, and **Output Mediation** aligned horizontally beneath it;
 - connected locations of requirement, operational, and runtime-judgment uncertainty;
-- one controlled object viewed across four decision horizons, rendered as one centered vertical decision-horizon spine in the canonical order Organization → Project / Architecture → Delivery → Runtime, with a separate upward reassessment lane preserving direct Runtime-to-Delivery, Runtime-to-Project / Architecture, and Runtime-to-Organization routes.
+- one controlled object viewed across four decision horizons, rendered as one centered vertical decision-horizon spine in the canonical order Organization → Project / Architecture → Delivery → Runtime. A single Runtime evidence node sits beneath Runtime. Direct dotted return routes lead from that evidence to Delivery, Project / Architecture, or Organization, with the invalidated decision basis written on the route itself. Reassessment criteria are routing conditions, not standalone architectural components or a separate subsystem.
 
 The Model Judgment placement figure is a taxonomy, not a sequence. It must not connect the three placement categories laterally in a way that implies a mandatory pipeline.
+
+For the four-horizon figure, keep each horizon block focused on the decision it owns rather than listing every responsibility. Downward edges should show authority and Constraints becoming more concrete. The caption must state that the figure shows decision ownership and reassessment routing, not a four-stage delivery workflow.
 
 **Repository anchors:**
 
@@ -949,7 +951,7 @@ Supporting figures currently expected:
 - Thinking Systems category boundary;
 - Model Judgment placement, with Model Judgment above and the three placement categories in one horizontal row beneath it;
 - connected uncertainty locations;
-- one controlled object across four decision horizons, with all four horizon blocks centered in one vertical line;
+- one controlled object across four decision horizons, with all four horizon blocks centered in one vertical line, one Runtime evidence node beneath them, and direct return routes to the level whose decision basis is invalidated; reassessment criteria belong on those routes rather than in a separate lane of component-like boxes;
 - closed feedback loop;
 - complete bounded control architecture;
 - organizational influence architecture;
@@ -1091,7 +1093,7 @@ Every article-writing PR must satisfy all of the following:
 - [ ] The consequence of an incomplete cross-level control architecture is explicit, scoped to readiness for production release at the intended scope, and visually emphasized once as a central engineering thesis without duplicating the argument.
 - [ ] Figure 3 places two vertical top-to-bottom responsibility diagrams side by side and uses restrained red treatment on the changed Thinking System blocks without implying that the entire system is probabilistic.
 - [ ] Figure 4 places Model Judgment above Input Interpretation, Decision Logic, and Output Mediation, with the three placements aligned horizontally and no implied mandatory sequence.
-- [ ] Figure 6 keeps Organization, Project / Architecture, Delivery, and Runtime in one centered vertical spine, preserves the downward inheritance labels, and shows separate upward reassessment routes from Runtime to the level that owns the invalidated decision.
+- [ ] Figure 6 keeps Organization, Project / Architecture, Delivery, and Runtime in one centered vertical spine, preserves concise downward inheritance labels, places one Runtime evidence node beneath Runtime, and routes invalidating evidence directly back to the owning decision level with the invalidated basis on the return edge rather than in a separate reassessment subsystem.
 - [ ] The decision-horizon bridge uses short bold-labeled paragraphs and keeps control-architecture design inside the project / architecture level.
 - [ ] Every major new argument has an appropriate figure or an explicit reason why prose is clearer.
 - [ ] All figures were reviewed as one visual sequence and renumbered consistently.

--- a/content/research/notes/open-engineering-specification-article-draft.md
+++ b/content/research/notes/open-engineering-specification-article-draft.md
@@ -240,9 +240,6 @@ flowchart TB
     MJ --> I
     MJ --> D
     MJ --> O
-
-    I ~~~ D
-    D ~~~ O
 ```
 
 **Figure 4 — Functional placement of Model Judgment.** Model Judgment is shown as the parent concept; Input Interpretation, Decision Logic, and Output Mediation are three functional placements beneath it. They are not mandatory stages or a prescribed execution order. A system may use one, several, or repeated instances of them, and each placement changes the controlled object in a different way.

--- a/content/research/notes/open-engineering-specification-article-draft.md
+++ b/content/research/notes/open-engineering-specification-article-draft.md
@@ -286,32 +286,24 @@ These activities use different evidence, participants, time horizons, and action
 Yet the levels are structurally connected because they control the same object.
 
 ```mermaid
-flowchart LR
-    subgraph H["Decision horizons"]
-        direction TB
-        O["Organization level<br/>authoritative boundaries, shared capabilities,<br/>prohibited uses, and decision rights"]
-        P["Project / architecture level<br/>technical credibility, operational supportability,<br/>economic viability, and control architecture"]
-        D["Delivery level<br/>bounded realization, evidence,<br/>release decision, and corrective readiness"]
-        R["Runtime level<br/>active behavior, operating conditions,<br/>correction, escalation, and reassessment"]
+flowchart TB
+    O["Organization<br/>What may be authorized?"]
+    P["Project / Architecture<br/>Is the controlled system viable and authorizable?"]
+    D["Delivery<br/>Is this bounded realization complete and releasable?"]
+    R["Runtime<br/>Does active operation remain inside the authorized boundary?"]
+    E["Runtime evidence<br/>behavior · outcomes · control state · changed assumptions"]
 
-        O -->|authoritative sources, shared capabilities,<br/>delegated authority| P
-        P -->|Project Constraint Architecture<br/>and authorized boundary| D
-        D -->|realized controls, release scope,<br/>active versions| R
-    end
+    O -->|authoritative sources + delegated authority| P
+    P -->|Project Constraint Architecture + authorization| D
+    D -->|realized boundary + release scope| R
+    R --> E
 
-    subgraph U["Upward reassessment routes"]
-        direction TB
-        UO["Source, decision right,<br/>or shared capability changed"]
-        UP["Risk, authority, capacity,<br/>evidence, or economics invalidated"]
-        UD["Local defect or<br/>implementation evidence"]
-    end
-
-    R -.-> UO -.-> O
-    R -.-> UP -.-> P
-    R -.-> UD -.-> D
+    E -.->|implementation / realization / evidence issue| D
+    E -.->|risk / authority / feasibility / capacity / economics invalidated| P
+    E -.->|authoritative source / decision right / shared capability changed| O
 ```
 
-**Figure 6 — One controlled object across four decision horizons.** The four decision horizons remain aligned in one vertical spine. Authority and Constraints flow downward by reference and become more concrete in realization. The separate return lane preserves the upward routes by which runtime evidence is sent directly to Delivery, Project / Architecture, or Organization when it invalidates the basis of a decision owned at that level.
+**Figure 6 — One controlled object across four decision horizons.** The same Thinking System is viewed through four decision horizons. Authority and Constraints become more concrete as they move downward from Organization to Project / Architecture, Delivery, and Runtime. Runtime evidence returns directly to the horizon whose authorization basis it invalidates. The figure shows decision ownership and reassessment routing, not a four-stage delivery workflow.
 
 At each level, the concrete subject changes, but a recurring control structure appears:
 


### PR DESCRIPTION
## Summary

Refine the article's Section 2 visual model in two places:

- fix Figure 4 so the three Model Judgment placement categories render as one horizontal row beneath the parent concept;
- redesign Figure 6 so it shows one controlled object across four decision horizons without treating reassessment criteria as a separate subsystem.

The editorial blueprint was reread and reconciled with the manuscript. Figure 4 keeps the existing taxonomy contract. Figure 6 now treats reassessment criteria as decision-basis routing conditions rather than architectural components.

## Scope

- Figure 4 keeps three direct sibling arrows from Model Judgment to Input Interpretation, Decision Logic, and Output Mediation;
- Figure 6 keeps one vertical decision spine: Organization → Project / Architecture → Delivery → Runtime;
- each horizon block is reduced to the decision it owns;
- authority and Constraints become more concrete downward;
- one Runtime evidence node sits beneath Runtime;
- runtime evidence returns directly to the decision horizon whose authorization basis it invalidates;
- reassessment conditions are labels on return routes, not standalone nodes;
- the blueprint figure contract and acceptance criterion were updated to preserve this design;
- no doctrine or terminology changes.

## Validation

- complete manuscript and blueprint were reconciled as the two living research documents required by `content/research/AGENTS.md`;
- Mermaid semantics were reviewed to avoid implying a mandatory execution sequence or a four-stage delivery waterfall;
- PR remains Draft while GitHub rendering and CI are reviewed.

<!-- ua-change-contract
{
  "change_class": "research",
  "owning_paths": [
    "content/research/notes/open-engineering-specification-article-draft.md",
    "content/research/notes/open-engineering-specification-article-blueprint.md"
  ],
  "decision_levels": ["organization", "project", "delivery", "runtime"],
  "capability_families": ["none"],
  "terminology_impact": "unchanged",
  "research_state": "unchanged",
  "compatibility": "preserved",
  "changelog": "not-required",
  "glossary": "unchanged",
  "roadmap": "unchanged",
  "traceability": "unchanged"
}
-->